### PR TITLE
Make it easier for contributors to know how to contribute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ tab_width = 4
 
 [*.php]
 insert_final_newline = true
+
+[*.md]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+max_line_length = 120
+tab_width = 4
+
+[*.php]
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,30 @@
 matrix:
-  include:
-    - language: node_js
-      node_js:
-        - '12'
-        - node
-      script:
-        - yarn lint
-      cache:
-        yarn: true
-    - language: php
-      php:
-        - '7.3'
-        - nightly
-      cache:
-        directories:
-          - $HOME/.composer/cache
-      before_script:
-        - composer self-update
-        - composer install --prefer-source --no-interaction --dev
-      script:
-        - vendor/bin/simple-phpunit
-#        - vendor/bin/phpstan analyse
-        - vendor/bin/phpcs
-  fast_finish: true
-  allow_failures:
-    - php: nightly
+    include:
+        - language: node_js
+          node_js:
+              - '12'
+              - node
+          script:
+              - yarn lint
+          cache:
+              yarn: true
+        - language: php
+          php:
+              - '7.3'
+              - nightly
+          cache:
+              directories:
+                  - $HOME/.composer/cache
+          before_script:
+              - composer self-update
+              - composer install --prefer-source --no-interaction --dev
+          script:
+              - vendor/bin/simple-phpunit
+              # - vendor/bin/phpstan analyse
+              - vendor/bin/phpcs
+    fast_finish: true
+    allow_failures:
+        - php: nightly
 
 notifications:
-  email: false
+    email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Coverd
+
+Thank you for showing interest in helping make this project better for all!
+
+## Code Style
+
+For PHP:
+
+  * Code Style: [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+  * Name Spaces: [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
+  * Static Analysis: [PHPStan](https://github.com/phpstan/phpstan)
+
+For JavaScript:
+  * eslint: [plugin:vue/recommended](https://vuejs.github.io/eslint-plugin-vue/rules/)
+
+## Submitting Issues & Feature Requests
+
+* You can create an issue [here](https://github.com/happybottoms/coverd/issues/new), but
+  before doing that please read the notes below on debugging and submitting issues,
+  and include as many details as possible with your report.
+* Include any of the following that you know: the version of Coverd you are using, the version of PHP you are using, the version of Yarn you are using, the OS, and the browser (and version).
+* Include any error messages you are receiving and under which conditions if this is a bug.
+* Try to make fixing this issue or adding this feature easier for the next person:
+  * For the application:
+    * If you submit a code-update, also submit appropriate tests
+    * If you don't submit a code-update, submit appropriate tests to show what you want improved
+* If you cannot supply tests, please be as descriptive as possible regarding the problem to be fixed or the feature you are wanting added.
+
+## Pull Requests
+
+* Ensure that you are using the latest pre-release version of Coverd
+* Javascript: we use [yarn](https://yarnpkg.com) and not [npm](https://www.npmjs.com/)
+  * In other words, you can update [package.json](package.json) and [yarn.lock](yarn.lock) but not `package-lock.json`
+* Include screenshots and animated GIFs in your pull request whenever possible.
+* Follow the whitespace/newline styles suggested in the [.editorconfig](.editorconfig) file (see: [editorconfig.org](http://editorconfig.org/) for information about this file).
+* Run `yarn lint --fix`, `composer lint-fix`, and `composer analyze`. Fix any problems found before submitting your pull request.
+
+## Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference issues and pull requests liberally
+* Reference: https://chris.beams.io/posts/git-commit/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ Thank you for showing interest in helping make this project better for all!
 
 For PHP:
 
-  * Code Style: [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
-  * Name Spaces: [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
-  * Static Analysis: [PHPStan](https://github.com/phpstan/phpstan)
+* Code Style: [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+* Name Spaces: [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
+* Static Analysis: [PHPStan](https://github.com/phpstan/phpstan)
 
 For JavaScript:
-  * eslint: [plugin:vue/recommended](https://vuejs.github.io/eslint-plugin-vue/rules/)
+* eslint: [plugin:vue/recommended](https://vuejs.github.io/eslint-plugin-vue/rules/)
 
 ## Submitting Issues & Feature Requests
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ You should now be able to connect to your the dev server at http://localhost:808
 
 1. `docker/yarn`
 
+## Work With the Dev Environment
+
+We have fixtures to define basic users of certain roles:
+
+  - admin (sees everything):
+    - **email:** admin@example.com
+    - **password:** password
+  - manager:
+    - **email:** manager@example.com
+    - **password:** password
+  - volunteer:
+    - **email:** volunteer@example.com
+    - **password:** password
+      
+Most of the time in development, you will probably want to log in as the admin. when needing to check access for certain types of users, log in as the appropriate role-based user.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,22 +4,22 @@ version: '3.1'
 services:
     app:
         build:
-          context: ./docker
-          dockerfile: Dockerfile
+            context: ./docker
+            dockerfile: Dockerfile
         volumes:
             - ./:/app:cached
             - var:/app/var
         depends_on:
-          - db
+            - db
     nginx:
         image: nginx
         ports:
-          - 8080:80
+            - 8080:80
         volumes:
-          - ./:/app:ro,cached
-          - ./docker/app.nginx.conf:/etc/nginx/conf.d/default.conf
+            - ./:/app:ro,cached
+            - ./docker/app.nginx.conf:/etc/nginx/conf.d/default.conf
         depends_on:
-          - app
+            - app
     db:
         image: postgres
         environment:

--- a/docker/app
+++ b/docker/app
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 docker-compose exec app $@

--- a/docker/composer
+++ b/docker/composer
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 docker-compose exec app composer @$

--- a/docker/install
+++ b/docker/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm .env.local
 cp .env.docker .env.local
 

--- a/docker/yarn
+++ b/docker/yarn
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 docker-compose exec app yarn watch

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="config/bootstrap.php"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
+    backupGlobals="false"
+    colors="true"
+    bootstrap="config/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />


### PR DESCRIPTION
This is largely a documentation change with some additional changes to file formatting due to the addition of an [.editorconfig](https://editorconfig.org/) file. This is in preparation for [Hacktoberfest](https://hacktoberfest.digitalocean.com/) #44 , which starts in just a few days.

When submitting a PR in github, github will ask the submitter if they have checked out the `CONTRIBUTING.md` if-and-only-if that file exists. This helps ensure that we get PRs with code that is properly formatted as well as issues that are more explicit.

**Note:** the amount of spaces per indent per filetype is up for debate. This is to get us started. If, at some point, we decide that, for instance, json files, require 2 spaces per indent, then that can be a separate PR.