### PR TITLE
Docker Setup Improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,9 @@ FROM php:7.3-fpm
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 # Prep for downloading Yarn
-RUN apt-get update && apt-get install -y gnupg
+RUN apt-get update && apt-get install -y gnupg apt-transport-https
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/docker/install
+++ b/docker/install
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-rm .env.local
-cp .env.docker .env.local
+docker-compose exec app rm .env.local
+docker-compose exec app cp .env.docker .env.local
 
-composer install
+docker-compose exec app composer install
 
 # start fresh
-bin/console doctrine:database:drop --force
-bin/console doctrine:database:create
-bin/console doctrine:schema:create
-bin/console doctrine:fixtures:load -n
+docker-compose exec app bin/console doctrine:database:drop --force
+docker-compose exec app bin/console doctrine:database:create
+docker-compose exec app bin/console doctrine:schema:create
+docker-compose exec app bin/console doctrine:fixtures:load -n
 
-yarn install
-yarn dev
+docker-compose exec app yarn install
+docker-compose exec app yarn dev


### PR DESCRIPTION
I ran into a few issues when pulling down the project and setting up docker,  decided to make a PR with some improvements.

- `apt-transport-https` is missing from the root docker image, this causes apt-get update to fail when combined with `https://*` repositories in the `sources.list.d`
- Node 4.x was being installed in the container so I've added the current Node LTS repository
- The `docker/install` script ran all of the commands on the host machine rather than the container, this caused several failures including the doctrine commands to fail connecting to the database