### PR TITLE
Add CodeClimate coverage testing for PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter
-              - ./cc-test-reporter before-build
+              - ./cc-test-reporter --debug before-build
           before_script:
               - composer self-update
               - composer install --prefer-source --no-interaction --dev
@@ -35,8 +35,8 @@ matrix:
               - vendor/bin/phpcs
               # Pipe the coverage data to Code Climate
           after_script:
-              - ./cc-test-reporter format-coverage -t clover -o coverage/codeclimate.json # Backend coverage
-              - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi  # Upload coverage/codeclimate.json
+              - ./cc-test-reporter --debug format-coverage -t clover -o coverage/codeclimate.json # Backend coverage
+              - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter --debug upload-coverage; fi  # Upload coverage/codeclimate.json
     fast_finish: true
     allow_failures:
         - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
               - composer install --prefer-source --no-interaction --dev
               - ./vendor/bin/simple-phpunit install
           script:
-              - vendor/bin/simple-phpunit -vvv --coverage-clover clover.xml
+              - vendor/bin/simple-phpunit -vv --coverage-clover clover.xml
               # - vendor/bin/phpstan analyse
               - vendor/bin/phpcs
               # Pipe the coverage data to Code Climate

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
               - composer install --prefer-source --no-interaction --dev
               - ./vendor/bin/simple-phpunit install
           script:
-              - vendor/bin/simple-phpunit $PHPUNIT_FLAGS
+              - vendor/bin/simple-phpunit -vvv --coverage-clover clover.xml
               # - vendor/bin/phpstan analyse
               - vendor/bin/phpcs
               # Pipe the coverage data to Code Climate

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         - language: php
           php:
               - '7.3'
-                env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+                env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover"
               - nightly
           cache:
               directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ matrix:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter
               - ./cc-test-reporter before-build
-          install:
-              ./vendor/bin/simple-phpunit install
           before_script:
               - composer self-update
               - composer install --prefer-source --no-interaction --dev
+              - ./vendor/bin/simple-phpunit install
           script:
               - vendor/bin/simple-phpunit $PHPUNIT_FLAGS
               # - vendor/bin/phpstan analyse

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
                   - $HOME/symfony-bridge/.phpunit
           env:
               global:
-                  - PHPUNIT_FLAGS="-v --coverage-clover clover.xml"
+                  - PHPUNIT_FLAGS="-vvv --coverage-clover clover.xml"
                   - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,16 @@ matrix:
         - language: php
           php:
               - '7.3'
+                env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
               - nightly
           cache:
               directories:
-                  - $HOME/.composer/cache
+                  - $HOME/.composer/cache/files
+                  - $HOME/symfony-bridge/.phpunit
+          env:
+              global:
+                  - PHPUNIT_FLAGS="-v"
+                  - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
           cache:
               yarn: true
         - language: php
-          php:
-              - '7.3'
+          include:
+              - php: '7.3'
                 env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover"
-              - nightly
+              - php: nightly
           cache:
               directories:
                   - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,27 +16,25 @@ matrix:
           cache:
               directories:
                   - $HOME/.composer/cache/files
-                  - $HOME/symfony-bridge/.phpunit
+                  - $HOME/bin/.phpunit
           env:
               global:
-                  - PHPUNIT_FLAGS="-vvv --coverage-clover clover.xml"
                   - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter
-              - ./cc-test-reporter --debug before-build
+              - ./cc-test-reporter before-build
           before_script:
               - composer self-update
               - composer install --prefer-source --no-interaction --dev
               - ./vendor/bin/simple-phpunit install
           script:
-              - vendor/bin/simple-phpunit -vv --coverage-clover clover.xml
+              - vendor/bin/simple-phpunit -v --coverage-clover clover.xml
               # - vendor/bin/phpstan analyse
               - vendor/bin/phpcs
-              # Pipe the coverage data to Code Climate
           after_script:
-              - ./cc-test-reporter --debug format-coverage -t clover # Backend coverage
-              - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter --debug upload-coverage; fi  # Upload coverage/codeclimate.json
+              - ./cc-test-reporter format-coverage -t clover # Backend coverage
+              - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi  # Upload coverage/codeclimate.json
     fast_finish: true
     allow_failures:
         - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
                   - $HOME/symfony-bridge/.phpunit
           env:
               global:
-                  - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover"
+                  - PHPUNIT_FLAGS="-v --coverage-clover clover.xml"
                   - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,13 @@ matrix:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter
               - ./cc-test-reporter before-build
+          install:
+              ./vendor/bin/simple-phpunit install
           before_script:
               - composer self-update
               - composer install --prefer-source --no-interaction --dev
           script:
-              - vendor/bin/simple-phpunit
+              - vendor/bin/simple-phpunit $PHPUNIT_FLAGS
               # - vendor/bin/phpstan analyse
               - vendor/bin/phpcs
               # Pipe the coverage data to Code Climate

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,16 @@ matrix:
           cache:
               yarn: true
         - language: php
-          include:
-              - php: '7.3'
-                env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text --coverage-clover"
-              - php: nightly
+          php:
+              - '7.3'
+              - nightly
           cache:
               directories:
                   - $HOME/.composer/cache/files
                   - $HOME/symfony-bridge/.phpunit
           env:
               global:
-                  - PHPUNIT_FLAGS="-v"
+                  - PHPUNIT_FLAGS="-v --coverage-text --coverage-clover"
                   - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
           cache:
               directories:
                   - $HOME/.composer/cache
+          before_install:
+              - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+              - chmod +x ./cc-test-reporter
+              - ./cc-test-reporter before-build
           before_script:
               - composer self-update
               - composer install --prefer-source --no-interaction --dev
@@ -23,6 +27,10 @@ matrix:
               - vendor/bin/simple-phpunit
               # - vendor/bin/phpstan analyse
               - vendor/bin/phpcs
+              # Pipe the coverage data to Code Climate
+          after_script:
+              - ./cc-test-reporter format-coverage -t clover -o coverage/codeclimate.json # Backend coverage
+              - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi  # Upload coverage/codeclimate.json
     fast_finish: true
     allow_failures:
         - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
               - vendor/bin/phpcs
               # Pipe the coverage data to Code Climate
           after_script:
-              - ./cc-test-reporter --debug format-coverage -t clover -o coverage/codeclimate.json # Backend coverage
+              - ./cc-test-reporter --debug format-coverage -t clover # Backend coverage
               - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter --debug upload-coverage; fi  # Upload coverage/codeclimate.json
     fast_finish: true
     allow_failures:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Coverd is an open source Symfony/Vue.js web application that manages the inventory and distribution of donated goods in a `Bank -> Partner -> Client` model. While this app was developed for diaper banks, our intent is for Coverd to be product agnostic.
 
 [![Build Status](https://travis-ci.org/happybottoms/coverd.svg?branch=master)](https://travis-ci.org/happybottoms/coverd)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/9faff8ad8d54cabb1ab8/test_coverage)](https://codeclimate.com/github/happybottoms/coverd/test_coverage)
 
 ![Coverd Screenshot](doc/screenshot.png)
 


### PR DESCRIPTION
This adds PHP test coverage via [CodeClimate](https://codeclimate.com/github/happybottoms/coverd). As of this PR, Travis-CI runs the PHPUnit tests and submits the Clover coverage report to CodeClimate, which then analyzes the code coverage and lets us know which PHP files need code coverage ([Example](https://codeclimate.com/repos/5da00035611324017800c80c/settings/test_reports/5dafdec9895dd336e500a5d2)).

### Future work:

* Need to figure out how to get both JS and PHP code coverage. This might require storing intermediate coverage files in temporary storage somewhere (ex AWS), so I'll create a separate ticket on how to run code coverage for both JS & PHP.
* CodeClimate also provides a really nice [interface for showing where code can be improved](https://codeclimate.com/github/happybottoms/coverd/issues). I've not provided a badge for this since I don't know how useful this info is for us. This might be worth looking at for at least some refactorings.

**Note:** Prior to merging to master, let's merge as a squash since there are a lot of test commits in this PR :)