### PR TITLE
Adding test coverage for Client and Name

### DIFF
--- a/tests/Entity/ClientTest.php
+++ b/tests/Entity/ClientTest.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace App\Tests\Entity;
+
+use App\Entity\Client;
+use App\Entity\ValueObjects\Name;
+use App\Tests\AbstractWebTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+
+class ClientTest extends AbstractWebTestCase
+{
+
+    public function testConstructorGeneratesUuid()
+    {
+        $client      = new Client();
+        $uuid        = $client->getUuid();
+        $isValidUuid = Uuid::isValid($uuid);
+        $this->assertTrue($isValidUuid, "UUID: {$uuid}");
+    }
+
+    public function testSetNameThrowsExceptionWhenInvalid()
+    {
+        $this->expectException(MissingMandatoryParametersException::class);
+        $this->expectExceptionMessage('Missing first and/or last name');
+        $name   = new Name();
+        $client = new Client();
+        $client->setName($name);
+    }
+
+}

--- a/tests/Entity/ValueObjects/NameTest.php
+++ b/tests/Entity/ValueObjects/NameTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Entity\ValueObjects;
+
+use App\Entity\ValueObjects\Name;
+use App\Tests\AbstractWebTestCase;
+
+class NameTest extends AbstractWebTestCase
+{
+    /**
+     * @testWith    ["Rosalind", "Franklin"]
+     *              ["Retta", null]
+     *              [null, "Lovelace"]
+     */
+    public function testIsValidReturnsTrueWhenFirstAndOrLastSet($first, $last)
+    {
+        $name = new Name($first, $last);
+        $this->assertTrue($name->isValid());
+    }
+
+    public function testIsValidReturnsFalseWhenFirstAndLastMissing()
+    {
+        $name = new Name();
+        $this->assertFalse($name->isValid());
+    }
+}


### PR DESCRIPTION
In support of #26, add unit test coverage for Client, and Name.

The error message for `Client->setName` seems to indicate both First and Last names are required, however, the code actually only enforces one or the other. I wrote tests specifically for Name to be sure that was the case. So I wrote these tests to enforce the current behavior. 

If the desired behavior is actually that *both* names are required we can easily change the tests and swap the `||` in `Name->isValid` for an `&&`. But I would do that in a separate PR.