### PR TITLE
Bugfix/coverd79 product categories not updating

### DIFF
--- a/assets/js/views/product/ProductCategoryEdit.vue
+++ b/assets/js/views/product/ProductCategoryEdit.vue
@@ -140,7 +140,7 @@
                         });
                 } else {
                     axios
-                        .patch('/api/' + this.apiPath + '/' + this.$route.params.id, this.listOption)
+                        .patch('/api' + this.$route.path, this.listOption)
                         .then(response => self.$router.push('/' + this.apiPath))
                         .catch(function (error) {
                             console.log(error);
@@ -153,7 +153,7 @@
             deleteListOption: function() {
                 let self = this;
                 axios
-                    .delete('/api/' + this.apiPath + '/' + this.$route.params.id)
+                    .delete('/api' + this.$route.path)
                     .then(response => self.$router.push('/' + this.apiPath));
             }
         }

--- a/assets/js/views/product/ProductCategoryEdit.vue
+++ b/assets/js/views/product/ProductCategoryEdit.vue
@@ -106,7 +106,11 @@
         components : {
             'modal' : Modal
         },
-        props: ['new', 'name', 'apiPath'],
+        props: {
+            new: { type: Boolean },
+            name: { type: String, default: '' },
+            apiPath: { type: String, default: '', required: true }
+        },
         data() {
             return {
                 listOption: {
@@ -115,7 +119,7 @@
             };
         },
         created() {
-            var self = this;
+            let self = this;
             if (!this.new) {
                 axios
                     .get('/api/' + this.apiPath + '/' + this.$route.params.id)
@@ -125,7 +129,7 @@
         },
         methods: {
             save: function () {
-                var self = this;
+                let self = this;
                 if (this.new) {
                     axios
                         .post('/api/' + this.apiPath, this.listOption)
@@ -146,10 +150,10 @@
                 $('#confirmModal').modal('show');
             },
             deleteListOption: function() {
-                var self = this;
+                let self = this;
                 axios
                     .delete('/api/' + this.apiPath + '/' + this.$route.params.id)
-                    .then(self.$router.push('/' + this.apiPath));
+                    .then(response => self.$router.push('/' + this.apiPath));
             }
         }
     }

--- a/assets/js/views/product/ProductCategoryEdit.vue
+++ b/assets/js/views/product/ProductCategoryEdit.vue
@@ -101,7 +101,8 @@
 
 
 <script>
-    import Modal from '../../components/Modal.vue';
+    import Modal from '../../components/Modal';
+
     export default {
         components : {
             'modal' : Modal

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,47 +196,7 @@ parameters:
 			path: src/Controller/HomeController.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 115$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\ListOptionController\\:\\:update\\(\\) has parameter \\$id with no typehint specified\\.$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 150$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\ListOptionController\\:\\:destroy\\(\\) has parameter \\$id with no typehint specified\\.$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 52$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on App\\\\Entity\\\\ListOption\\|null\\.$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\ListOptionController\\:\\:getListOption\\(\\) has parameter \\$id with no typehint specified\\.$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\$id\\)\\: Unexpected token \"\\$id\", expected type at offset 18$#"
-			count: 1
-			path: src/Controller/ListOptionController.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between App\\\\Entity\\\\ListOption and null will always evaluate to false\\.$#"
 			count: 1
 			path: src/Controller/ListOptionController.php
 

--- a/src/Controller/ListOptionController.php
+++ b/src/Controller/ListOptionController.php
@@ -100,6 +100,7 @@ abstract class ListOptionController extends BaseController
     /**
      * Delete a listOption
      *
+     * @Route(path="/{id<\d+>}", methods={"DELETE"})
      * @param $id
      * @return JsonResponse
      */

--- a/src/Controller/ListOptionController.php
+++ b/src/Controller/ListOptionController.php
@@ -25,10 +25,8 @@ abstract class ListOptionController extends BaseController
      * Get a list of ListOptions
      *
      * @Route(path="", methods={"GET"})
-     * @param Request $request
-     * @return JsonResponse
      */
-    public function index(Request $request)
+    public function index(Request $request): JsonResponse
     {
         $listOptions = $this->getRepository()->findAll();
 
@@ -39,11 +37,8 @@ abstract class ListOptionController extends BaseController
      * Get a single ListOption
      *
      * @Route(path="/{id<\d+>}", methods={"GET"})
-     * @param Request $request
-     * @param $id
-     * @return JsonResponse
      */
-    public function show(Request $request, int $id)
+    public function show(Request $request, int $id): JsonResponse
     {
         $listOption = $this->getListOption($id);
 
@@ -54,12 +49,8 @@ abstract class ListOptionController extends BaseController
      * Save a new listOption
      *
      * @Route(path="", methods={"POST"})
-     * @param Request $request
-     * @param ValidatorInterface $validator
-     *
-     * @return JsonResponse
      */
-    public function store(Request $request, ValidatorInterface $validator)
+    public function store(Request $request, ValidatorInterface $validator): JsonResponse
     {
         $listOption = $this->getListOptionEntityInstance();
         $listOption->setName($request->get('name'));
@@ -78,12 +69,9 @@ abstract class ListOptionController extends BaseController
     /**
      * Whole or partial update of a listOption
      *
-     * @Route(path="/{id}", methods={"PATCH"})
-     * @param Request $request
-     * @param $id
-     * @return JsonResponse
+     * @Route(path="/{id<\d+>}", methods={"PATCH"})
      */
-    public function update(Request $request, $id)
+    public function update(Request $request, int $id): JsonResponse
     {
         $params = $this->getParams($request);
         /** @var ListOption $listOption */
@@ -101,10 +89,8 @@ abstract class ListOptionController extends BaseController
      * Delete a listOption
      *
      * @Route(path="/{id<\d+>}", methods={"DELETE"})
-     * @param $id
-     * @return JsonResponse
      */
-    public function destroy($id)
+    public function destroy(int $id): JsonResponse
     {
         $listOption = $this->getListOption($id);
         $this->getEm()->remove($listOption);
@@ -115,16 +101,14 @@ abstract class ListOptionController extends BaseController
     }
 
     /**
-     * @param $id
-     * @return null|ListOption
      * @throws NotFoundHttpException
      */
-    protected function getListOption($id)
+    protected function getListOption(int $id): ListOption
     {
         /** @var ListOption $listOption */
         $listOption = $this->getRepository()->find($id);
 
-        if (!$listOption) {
+        if ($listOption === null) {
             throw new NotFoundHttpException(sprintf('Unknown ListOption ID: %d', $id));
         }
 

--- a/src/Controller/ListOptionController.php
+++ b/src/Controller/ListOptionController.php
@@ -38,7 +38,7 @@ abstract class ListOptionController extends BaseController
     /**
      * Get a single ListOption
      *
-     * @Route(path="/{id}")
+     * @Route(path="/{id<\d+>}", methods={"GET"})
      * @param Request $request
      * @param $id
      * @return JsonResponse


### PR DESCRIPTION
The problem was basically that the method we were assuming was being used for GET was the default controller method for all API calls to `api/product-categories/{id}` since it didn't have an HTTP verb explicitly set. This PR fixes that.

Unfortunately, this also fixes the "delete" button for product categories. I say _unfortunately_ because if the product category is currently used in a product, a nasty SQL error gets thrown. See #84 

Also fixed are static-analyzer problems on the same file as well as some eslint fixes for the calling UI.