### PR TITLE
Make it easier to run dockerized yarn commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You should now be able to connect to your the dev server at http://localhost:808
 
 ### Build and watch the Vue JS app
 
-1. `docker/yarn`
+1. `docker/yarn watch`
 
 ## Work With the Dev Environment
 

--- a/docker/yarn
+++ b/docker/yarn
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose exec app yarn watch
+docker-compose exec app yarn $@


### PR DESCRIPTION
This brings docker/yarn to how our various dockerized commands are run. 

* app --> `docker/app cmd`
* composer --> `docker/composer cmd`

**Before this change:**
It's easy to use the yarn command to watch the dev server via `docker/yarn` and convoluted to get yarn to do anything else, like run eslint: `docker/app yarn lint`

**After this change:**
* yarn cmd--> `docker/yarn cmd`
* `yarn watch` --> `docker/yarn watch`
* `yarn lint` --> `docker/yarn lint`