### PR TITLE
Make dockerized xdebug work

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -13,6 +13,12 @@
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
+###> XDEBUG ###
+# On linux, use the host IP address for XDEBUG_CONFIG
+PHP_IDE_CONFIG=serverName=coverd
+XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000
+###< XDEBUG ###
+
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=b347827c3b9fc3104793837773602b70

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Learn More at https://www.happybottoms.org
 
 ## Development Installation - Docker Compose
 
+1. Copy `.env.docker` to `.env.local`
 1. `docker-compose up --build`
 1. `docker-compose exec app docker/install`
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You should now be able to connect to your the dev server at http://localhost:808
 
 1. `docker/yarn`
 
+### Debugging with Xdebug
+
+1. In the "app" service of `docker-compose.yml`, change `WITH_XDEBUG=false` to `WITH_XDEBUG=true`
+1. Rebuild your environment: `docker-compose up --build`
+1. If using PHPStorm, make sure you set your xdebug server to have the name "coverd"
+
 ## Work With the Dev Environment
 
 We have fixtures to define basic users of certain roles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             - ./:/app:cached
             - var:/app/var
             - ./docker/config/app.php.ini:/usr/local/etc/php/conf.d/coverd-overrides.ini
+        env_file: .env.local
         depends_on:
             - db
     nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         build:
             context: ./docker
             dockerfile: Dockerfile
+            args:
+                - WITH_XDEBUG=false
         volumes:
             - ./:/app:cached
             - var:/app/var

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 
-## install xdebug
+# install xdebug
 #RUN yes | pecl install xdebug \
 #    && echo "[xdebug]" > /usr/local/etc/php/conf.d/xdebug.ini \
 #    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" >> /usr/local/etc/php/conf.d/xdebug.ini \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install -j$(nproc) zip \
+    && docker-php-ext-install -j$(nproc) opcache \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo pdo_pgsql pgsql
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,11 +31,19 @@ RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 
 # install xdebug
-#RUN yes | pecl install xdebug \
-#    && echo "[xdebug]" > /usr/local/etc/php/conf.d/xdebug.ini \
-#    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" >> /usr/local/etc/php/conf.d/xdebug.ini \
-#    && echo "xdebug.remote_enable=0" >> /usr/local/etc/php/conf.d/xdebug.ini \
-#    && echo "xdebug.remote_port=9000" >> /usr/local/etc/php/conf.d/xdebug.ini
-
+ARG WITH_XDEBUG=false
+ARG XDEBUG_INI=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+RUN \
+     if $WITH_XDEBUG; then \
+        pecl install xdebug; \
+        docker-php-ext-enable xdebug; \
+        echo "error_reporting = E_ALL" >> ${XDEBUG_INI}; \
+        echo "display_startup_errors = 1" >> ${XDEBUG_INI}; \
+        echo "display_errors = 1" >> ${XDEBUG_INI}; \
+        echo "xdebug.remote_enable = 1" >> ${XDEBUG_INI}; \
+        echo "xdebug.remote_autostart = 0" >> ${XDEBUG_INI}; \
+        echo "xdebug.remote_connect_back = 0" >> ${XDEBUG_INI}; \
+        echo "xdebug.max_nesting_level = 1500" >> ${XDEBUG_INI}; \
+     fi ;
 
 WORKDIR /app

--- a/docker/config/app.nginx.conf
+++ b/docker/config/app.nginx.conf
@@ -15,5 +15,6 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        proxy_read_timeout 180s;
     }
 }


### PR DESCRIPTION
This gets xdebug working on a dev environment.

This also provides a minor speed boost using PHPs opcache. 

I followed [this as a guide](https://dev.to/brpaz/docker-phpstorm-and-xdebug-the-definitive-guide-14og). After this gets accepted, I'll create documentation for getting it working in PHPStorm.