### PR TITLE
Partner Order Voters

### DIFF
--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -6,6 +6,7 @@ use App\Entity\LineItem;
 use App\Entity\Order;
 use App\Entity\Product;
 use App\Exception\CommittedTransactionException;
+use App\Security\PartnerOrderVoter;
 use App\Transformers\OrderTransformer;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -72,13 +73,12 @@ class OrderController extends BaseController
      * Get a single Order
      *
      * @Route(path="/{id<\d+>}", methods={"GET"})
-     *
-     * @param $id
-     * @return array
      */
     public function show(Request $request, $id)
     {
         $order = $this->getOrder($id);
+
+        $this->denyAccessUnlessGranted(PartnerOrderVoter::VIEW, $order);
 
         return $this->serialize($request, $order);
     }

--- a/src/Controller/PartnerOrderController.php
+++ b/src/Controller/PartnerOrderController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\Orders\PartnerOrder;
 use App\Entity\Orders\PartnerOrderLineItem;
 use App\Entity\Partner;
+use App\Entity\User;
 use App\Entity\Warehouse;
 use App\Transformers\BagTransformer;
 use App\Transformers\PartnerOrderTransformer;
@@ -143,6 +144,14 @@ class PartnerOrderController extends OrderController
         }
         if ($request->get('partner')) {
             $params->set('partner', $this->getRepository(Partner::class)->find($request->get('partner')));
+        }
+
+        /** @var User $user */
+        $user = $this->getUser();
+
+        // If the user isn't an admin,
+        if (!$user->hasRole(PartnerOrder::ROLE_VIEW_ALL)) {
+            $params->set('partner', $user->getActivePartner());
         }
 
         return $params;

--- a/src/DataFixtures/GroupFixtures.php
+++ b/src/DataFixtures/GroupFixtures.php
@@ -4,6 +4,7 @@ namespace App\DataFixtures;
 
 use App\Entity\Group;
 use App\Entity\Order;
+use App\Entity\Partner;
 use App\Entity\Product;
 use App\Entity\Supplier;
 use App\Entity\Warehouse;
@@ -28,7 +29,7 @@ class GroupFixtures extends BaseFixture
         $volunteer = new Group();
         $volunteer->setName('Volunteer');
         $volunteer->setRoles([
-            Order::ROLE_EDIT,
+            Order::ROLE_EDIT_ALL,
             Order::ROLE_VIEW_ALL,
             Product::ROLE_VIEW,
             Supplier::ROLE_VIEW,
@@ -41,7 +42,8 @@ class GroupFixtures extends BaseFixture
         $partner = new Group();
         $partner->setName('Partner');
         $partner->setRoles([
-            Order::ROLE_VIEW_OWN,
+            Order::ROLE_MANAGE_OWN,
+            Partner::ROLE_MANAGE_OWN,
         ]);
         $em->persist($partner);
         $this->setReference('group_partner', $partner);

--- a/src/DataFixtures/PartnerOrderFixtures.php
+++ b/src/DataFixtures/PartnerOrderFixtures.php
@@ -26,7 +26,7 @@ class PartnerOrderFixtures extends BaseFixture implements DependentFixtureInterf
         /** @var Product[] $products */
         $products = $manager->getRepository(Product::class)->findByPartnerOrderable();
 
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 50; $i++) {
             /** @var Partner $partner */
             $partner = $this->faker->randomElement($partners);
 

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -21,9 +21,11 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Group extends CoreEntity
 {
     const AVAILABLE_ROLES = [
-        Order::ROLE_VIEW_OWN,
+        User::ROLE_ADMIN,
+
+        Order::ROLE_MANAGE_OWN,
         Order::ROLE_VIEW_ALL,
-        Order::ROLE_EDIT,
+        Order::ROLE_EDIT_ALL,
 
         Supplier::ROLE_VIEW,
         Supplier::ROLE_EDIT,
@@ -32,8 +34,8 @@ class Group extends CoreEntity
         Warehouse::ROLE_EDIT,
 
         Partner::ROLE_VIEW_ALL,
-        Partner::ROLE_VIEW_SELF,
-        Partner::ROLE_EDIT,
+        Partner::ROLE_EDIT_ALL,
+        Partner::ROLE_MANAGE_OWN,
 
         Product::ROLE_VIEW,
         Product::ROLE_EDIT,

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -23,9 +23,9 @@ abstract class Order extends CoreEntity
 {
     const STATUS_COMPLETED = "COMPLETED";
 
-    const ROLE_VIEW_OWN = "ROLE_ORDER_VIEW_OWN";
     const ROLE_VIEW_ALL = "ROLE_ORDER_VIEW_ALL";
-    const ROLE_EDIT = "ROLE_ORDER_EDIT";
+    const ROLE_EDIT_ALL = "ROLE_ORDER_EDIT_ALL";
+    const ROLE_MANAGE_OWN = "ROLE_ORDER_MANAGE_OWN";
 
     /**
      * @var int

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -25,8 +25,8 @@ class Partner extends StorageLocation
     ];
 
     const ROLE_VIEW_ALL = 'ROLE_PARTNER_VIEW_ALL';
-    const ROLE_VIEW_SELF = 'ROLE_PARTNER_VIEW_SELF';
-    const ROLE_EDIT = 'ROLE_PARTNER_EDIT';
+    const ROLE_EDIT_ALL = 'ROLE_PARTNER_EDIT_ALL';
+    const ROLE_MANAGE_OWN = 'ROLE_PARTNER_MANAGE_OWN';
 
     /**
      * @var string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -20,6 +20,7 @@ class User extends CoreEntity implements UserInterface
     public const ROLE_VIEW = 'ROLE_USER_VIEW';
     public const ROLE_EDIT = 'ROLE_USER_EDIT';
     public const ROLE_ADMIN = 'ROLE_ADMIN';
+    public const ROLE_USER = 'ROLE_USER';
 
     /**
      * @ORM\Id()
@@ -160,9 +161,14 @@ class User extends CoreEntity implements UserInterface
         }
 
         // guarantee every user at least has ROLE_USER
-        $roles[] = 'ROLE_USER';
+        $roles[] = self::ROLE_USER;
 
         return array_unique($roles);
+    }
+
+    public function hasRole(string $role): bool
+    {
+        return in_array($role, $this->getRoles());
     }
 
     /**

--- a/src/Security/BulkDistributionVoter.php
+++ b/src/Security/BulkDistributionVoter.php
@@ -44,9 +44,9 @@ class BulkDistributionVoter extends Voter
                 return $this->canView($order, $user);
             case self::EDIT:
                 return $this->canEdit($order, $user);
+            default:
+                throw new \LogicException('This code should not be reached!');
         }
-
-        throw new \LogicException('This code should not be reached!');
     }
 
     private function canView(BulkDistribution $order, User $user)

--- a/src/Security/BulkDistributionVoter.php
+++ b/src/Security/BulkDistributionVoter.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Order;
+use App\Entity\Orders\BulkDistribution;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class BulkDistributionVoter extends Voter
+{
+    const EDIT = 'EDIT';
+    const VIEW = 'VIEW';
+
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
+
+        if (!$subject instanceof BulkDistribution) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            // the user must be logged in; if not, deny access
+            return false;
+        }
+
+        // you know $subject is a Post object, thanks to `supports()`
+        /** @var BulkDistribution $order */
+        $order = $subject;
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($order, $user);
+            case self::EDIT:
+                return $this->canEdit($order, $user);
+        }
+
+        throw new \LogicException('This code should not be reached!');
+    }
+
+    private function canView(BulkDistribution $order, User $user)
+    {
+        // if they can edit, they can view
+        if ($this->canEdit($order, $user)) {
+            return true;
+        }
+
+        // If they have the view all role, they can view
+        if ($user->hasRole(Order::ROLE_VIEW_ALL)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canEdit(BulkDistribution $order, User $user)
+    {
+        // Admin can do all the things
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        // If they have the edit all role, they can edit
+        if ($user->hasRole(Order::ROLE_EDIT_ALL)) {
+            return true;
+        }
+
+        $activePartner = $user->getActivePartner();
+
+        // If they have the manage own role, have an active partner, and this order is that partner's, they can edit
+        if ($user->hasRole(Order::ROLE_MANAGE_OWN)
+            && $activePartner
+            && $order->getPartner()->getId() === $activePartner->getId()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Security/PartnerOrderVoter.php
+++ b/src/Security/PartnerOrderVoter.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Order;
+use App\Entity\Orders\PartnerOrder;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class PartnerOrderVoter extends Voter
+{
+    const EDIT = 'EDIT';
+    const VIEW = 'VIEW';
+
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
+
+        if (!$subject instanceof PartnerOrder) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            // the user must be logged in; if not, deny access
+            return false;
+        }
+
+        // you know $subject is a Post object, thanks to `supports()`
+        /** @var PartnerOrder $order */
+        $order = $subject;
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($order, $user);
+            case self::EDIT:
+                return $this->canEdit($order, $user);
+        }
+
+        throw new \LogicException('This code should not be reached!');
+    }
+
+    private function canView(PartnerOrder $order, User $user)
+    {
+        // if they can edit, they can view
+        if ($this->canEdit($order, $user)) {
+            return true;
+        }
+
+        // If they have the view all role, they can view
+        if ($user->hasRole(Order::ROLE_VIEW_ALL)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canEdit(PartnerOrder $order, User $user)
+    {
+        // Admin can do all the things
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        // If they have the edit all role, they can edit
+        if ($user->hasRole(Order::ROLE_EDIT_ALL)) {
+            return true;
+        }
+
+        $activePartner = $user->getActivePartner();
+
+        // If they have the manage own role, have an active partner, and this order is that partner's, they can edit
+        if ($user->hasRole(Order::ROLE_MANAGE_OWN)
+            && $activePartner
+            && $order->getPartner()->getId() === $activePartner->getId()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Security/PartnerOrderVoter.php
+++ b/src/Security/PartnerOrderVoter.php
@@ -44,9 +44,9 @@ class PartnerOrderVoter extends Voter
                 return $this->canView($order, $user);
             case self::EDIT:
                 return $this->canEdit($order, $user);
+            default:
+                throw new \LogicException('This code should not be reached!');
         }
-
-        throw new \LogicException('This code should not be reached!');
     }
 
     private function canView(PartnerOrder $order, User $user)


### PR DESCRIPTION
Closes #100 

This PR adds voters for partner orders as well as adds a filter to the repository if the user doesn't have VIEW_ALL rights for the orders. This uses the "Active partner" feature to make sure lists are limited to the partner the user has selected in the case of the user being part of multiple partners.