### PR TITLE
Fix build errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,11 @@
     "env": {
         "browser": true
     },
+    "parser": "vue-eslint-parser",
+    "parserOptions": {
+        "parser": "babel-eslint",
+        "sourceType": "module"
+    },
     "rules": {
         // override/add rules settings here, such as:
         "vue/no-unused-vars": "error",

--- a/assets/js/components/AddressView.vue
+++ b/assets/js/components/AddressView.vue
@@ -14,7 +14,10 @@
             {{ value.street2 }}<br>
         </div>
 
-        <div v-if="value.city || value.state || value.postalCode" data-testid="city-state-postalcode">
+        <div
+            v-if="value.city || value.state || value.postalCode"
+            data-testid="city-state-postalcode"
+        >
             <span v-if="value.city"> {{ value.city }}, </span>
             <span v-if="value.state">
                 {{ value.state }}

--- a/assets/js/components/DisplayField.vue
+++ b/assets/js/components/DisplayField.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="form-group">
-        <label v-text="label" v-if="label"></label>
+        <label
+            v-if="label"
+            v-text="label"
+        />
         <div v-text="value" />
     </div>
 </template>

--- a/assets/js/components/KeyValueField.vue
+++ b/assets/js/components/KeyValueField.vue
@@ -9,7 +9,7 @@
             >
                 <div>
                     <div class="col-xs-1">
-                        <i class="fa fa-arrows"></i>
+                        <i class="fa fa-arrows" />
                     </div>
                     <div class="col-xs-5">
                         <input
@@ -30,16 +30,16 @@
                 </div>
             </div>
         </Draggable>
-        <button @click="addBlankPair">Add Option</button>
-
-
+        <button @click="addBlankPair">
+            Add Option
+        </button>
     </div>
 </template>
 
 <script>
-    import Draggable from 'vuedraggable';
+import Draggable from 'vuedraggable';
 
-    export default {
+export default {
         name: "NameValueField",
         components: {
             Draggable

--- a/assets/js/components/MultiOptionListEntity.vue
+++ b/assets/js/components/MultiOptionListEntity.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="form-group">
-        <label v-if="label" v-text="label" />
+        <label
+            v-if="label"
+            v-text="label"
+        />
         <select
             v-if="!groupProperty"
             v-model="value"

--- a/assets/js/components/NumberField.vue
+++ b/assets/js/components/NumberField.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <label v-text="label"></label>
+        <label v-text="label" />
         <input
             :value="value"
             type="number"

--- a/assets/js/components/OptionListApi.vue
+++ b/assets/js/components/OptionListApi.vue
@@ -17,7 +17,7 @@
                 v-for="item in options"
                 :key="item.id"
                 :selected="value == item.id"
-                v-bind:value="item.id"
+                :value="item.id"
                 v-text="item[displayProperty]"
             />
         </select>

--- a/assets/js/components/OptionListEntity.vue
+++ b/assets/js/components/OptionListEntity.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="form-group">
-        <label v-if="label" v-text="label" />
+        <label
+            v-if="label"
+            v-text="label"
+        />
         <select
             v-if="!groupProperty"
             v-model="value[property]"

--- a/assets/js/components/OptionListStatic.vue
+++ b/assets/js/components/OptionListStatic.vue
@@ -1,10 +1,13 @@
 <template>
     <div class="form-group">
-        <label v-if="label" v-text="label" />
+        <label
+            v-if="label"
+            v-text="label"
+        />
         <template v-if="chosen && loaded">
             <select
-                :value="value"
                 v-chosen
+                :value="value"
                 class="form-control"
                 :class="{'loaded': loaded}"
                 @change="onChange"

--- a/assets/js/components/Sidebar.vue
+++ b/assets/js/components/Sidebar.vue
@@ -47,9 +47,8 @@
 </template>
 
 <script>
-    import store from "../store";
 
-    export default {
+export default {
         props:[],
         data() {
             return {
@@ -116,6 +115,9 @@
                 ]
             }
         },
+        mounted() {
+            console.log('Component mounted.')
+        },
         methods: {
             hasAccess(linkRoute) {
                 if (!linkRoute) return true;
@@ -128,9 +130,6 @@
                 }
                 return true;
             }
-        },
-        mounted() {
-            console.log('Component mounted.')
         }
     }
 </script>

--- a/assets/js/components/Sidebar.vue
+++ b/assets/js/components/Sidebar.vue
@@ -28,8 +28,7 @@
                     class="treeview-menu"
                 >
                     <li
-                        v-for="link in menu.links"
-                        v-if="hasAccess(link.route)"
+                        v-for="link in routesUserCanAccess(menu.links)"
                         :key="link.id"
                     >
                         <router-link :to="link.route">
@@ -119,16 +118,16 @@ export default {
             console.log('Component mounted.')
         },
         methods: {
-            hasAccess(linkRoute) {
-                if (!linkRoute) return true;
-                let self = this;
-                let resolved = this.$router.resolve({name: linkRoute.name});
-                let route = resolved.route;
-                if (route?.meta?.roles) {
-                    let hasRoles = route.meta.roles.filter((role) => self.$store.getters.userHasRole(role));
-                    return hasRoles.length > 0;
-                }
-                return true;
+            routesUserCanAccess(links) {
+                return links.filter((link) => {
+                    let resolved = this.$router.resolve({name: link.name});
+                    let route = resolved.route;
+                    if (route?.meta?.roles) {
+                        let hasRoles = route.meta.roles.filter((role) => this.$store.getters.userHasRole(role));
+                        return hasRoles.length > 0;
+                    }
+                    return true;
+                }, this);
             }
         }
     }

--- a/assets/js/components/TextField.vue
+++ b/assets/js/components/TextField.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="form-group">
-        <label v-text="label" v-if="label"></label>
+        <label
+            v-if="label"
+            v-text="label"
+        />
         <input
             :value="value"
             type="text"

--- a/assets/js/components/TextareaField.vue
+++ b/assets/js/components/TextareaField.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="form-group">
-        <label v-text="label"></label>
+        <label v-text="label" />
         <textarea
             :value="value"
             class="form-control"

--- a/assets/js/components/ToggleField.vue
+++ b/assets/js/components/ToggleField.vue
@@ -5,7 +5,7 @@
                 :checked="value"
                 type="checkbox"
                 @change="$emit('input', $event.target.checked)"
-            /> {{ label }}
+            > {{ label }}
         </label>
     </div>
 </template>

--- a/assets/js/components/Userbar.vue
+++ b/assets/js/components/Userbar.vue
@@ -1,6 +1,9 @@
 <template>
     <ul class="nav navbar-nav">
-        <li v-if="userPartners.length > 0" class="dropdown admin-menu">
+        <li
+            v-if="userPartners.length > 0"
+            class="dropdown admin-menu"
+        >
             <a
                 id="partner-switch-dropdown"
                 href="#"
@@ -32,8 +35,6 @@
                     </a>
                 </li>
             </ul>
-
-
         </li>
         <!-- Authentication Links -->
         <li class="dropdown user admin-menu">
@@ -71,10 +72,10 @@
 </template>
 
 <script>
-    import { mapGetters } from 'vuex';
-    import axios from 'axios';
+import {mapGetters} from 'vuex';
+import axios from 'axios';
 
-    export default {
+export default {
         props:[],
         data() {
             return {
@@ -95,6 +96,9 @@
                 'userPartners'
             ])
         },
+        mounted() {
+            console.log('Component mounted.')
+        },
         methods: {
             switchPartner(id) {
                 let self = this;
@@ -104,9 +108,6 @@
                         self.$store.dispatch('loadCurrentUser')
                     });
             }
-        },
-        mounted() {
-            console.log('Component mounted.')
         }
     }
 </script>

--- a/assets/js/views/admin/UserEdit.vue
+++ b/assets/js/views/admin/UserEdit.vue
@@ -126,16 +126,18 @@
                                 Add Partner<i class="fa fa-fw fa-plus-circle" />
                             </button>
                             <table class="table table-hover">
-                                <tr v-for="partner in user.partners" :key="partner.id">
+                                <tr
+                                    v-for="partner in user.partners"
+                                    :key="partner.id"
+                                >
                                     <td v-text="partner.title" />
                                     <td>
                                         <button
                                             class="btn btn-success btn-flat"
                                             @click="onPartnerRemoveClick(partner.id)"
                                         >
-                                            <i class="fa fa-fw fa-trash"/>
+                                            <i class="fa fa-fw fa-trash" />
                                         </button>
-
                                     </td>
                                 </tr>
                             </table>
@@ -162,13 +164,13 @@
 
 
 <script>
-    import Modal from '../../components/Modal.vue';
-    import OptionListEntity from "../../components/OptionListEntity";
-    import { mapGetters, mapActions } from 'vuex';
-    import PartnerField from "../../components/PartnerField";
-    import PartnerSelectionForm from "../../components/PartnerSelectionForm";
+import Modal from '../../components/Modal.vue';
+import OptionListEntity from "../../components/OptionListEntity";
+import {mapGetters} from 'vuex';
+import PartnerField from "../../components/PartnerField";
+import PartnerSelectionForm from "../../components/PartnerSelectionForm";
 
-    export default {
+export default {
         components: {
             PartnerSelectionForm,
             PartnerField,

--- a/assets/js/views/admin/UserEdit.vue
+++ b/assets/js/views/admin/UserEdit.vue
@@ -165,16 +165,12 @@
 
 <script>
 import Modal from '../../components/Modal.vue';
-import OptionListEntity from "../../components/OptionListEntity";
 import {mapGetters} from 'vuex';
-import PartnerField from "../../components/PartnerField";
 import PartnerSelectionForm from "../../components/PartnerSelectionForm";
 
 export default {
         components: {
             PartnerSelectionForm,
-            PartnerField,
-            OptionListEntity,
             'modal' : Modal
         },
         props: ['new'],

--- a/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
@@ -49,7 +49,11 @@
                                 label="Interface Type"
                                 :preloaded-options="interfaceOptions"
                             />
-                            <KeyValueField v-if="selectedTypeHasOptions" v-model="definition.options" label="Options" />
+                            <KeyValueField
+                                v-if="selectedTypeHasOptions"
+                                v-model="definition.options"
+                                label="Options"
+                            />
                         </div>
                         <!-- /.box-body -->
                     </div>
@@ -61,11 +65,11 @@
 
 
 <script>
-    import KeyValueField from "../../../components/KeyValueField";
-    import {mapGetters} from "vuex";
-    import OptionListStatic from "../../../components/OptionListStatic";
+import KeyValueField from "../../../components/KeyValueField";
+import {mapGetters} from "vuex";
+import OptionListStatic from "../../../components/OptionListStatic";
 
-    export default {
+export default {
         name: 'AttributeDefinitionEdit',
         components: {
             OptionListStatic,
@@ -115,6 +119,9 @@
                 return !!attributeType.hasOptions;
             }
         },
+        mounted() {
+            this.$store.dispatch('loadTypes');
+        },
         methods: {
             save: function () {
                 let self = this;
@@ -150,9 +157,6 @@
 
                 return map[uiType];
             }
-        },
-        mounted() {
-            this.$store.dispatch('loadTypes');
         }
     }
 </script>

--- a/assets/js/views/admin/attributes/AttributeDefinitionList.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionList.vue
@@ -41,8 +41,14 @@
                                     <th>Updated</th>
                                 </tr>
                             </thead>
-                            <Draggable v-model="definitions" tag="tbody">
-                                <tr v-for="definition in definitions" :key="definition.id">
+                            <Draggable
+                                v-model="definitions"
+                                tag="tbody"
+                            >
+                                <tr
+                                    v-for="definition in definitions"
+                                    :key="definition.id"
+                                >
                                     <td><i class="fa fa-arrows" /></td>
                                     <td>
                                         <router-link
@@ -68,9 +74,9 @@
 </template>
 
 <script>
-    import Draggable from 'vuedraggable';
+import Draggable from 'vuedraggable';
 
-    export default {
+export default {
         name: "AttributeDefinitionList",
         components: {
             Draggable

--- a/assets/js/views/admin/attributes/ClientAttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/ClientAttributeDefinitionEdit.vue
@@ -5,15 +5,15 @@
         patch-api="/api/client/attribute/definition/"
         list-route="admin-client-attribute"
         definition-entity="Client"
-        :newForm="newForm"
+        :new-form="newForm"
     />
 </template>
 
 
 <script>
-    import AttributeDefinitionEdit from "./AttributeDefinitionEdit";
+import AttributeDefinitionEdit from "./AttributeDefinitionEdit";
 
-    export default {
+export default {
         components: {
             AttributeDefinitionEdit,
         },

--- a/assets/js/views/admin/attributes/PartnerAttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/PartnerAttributeDefinitionEdit.vue
@@ -5,15 +5,15 @@
         patch-api="/api/partner/attribute/definition/"
         list-route="admin-partner-attribute"
         definition-entity="Partner"
-        :newForm="newForm"
+        :new-form="newForm"
     />
 </template>
 
 
 <script>
-    import AttributeDefinitionEdit from "./AttributeDefinitionEdit";
+import AttributeDefinitionEdit from "./AttributeDefinitionEdit";
 
-    export default {
+export default {
         components: {
             AttributeDefinitionEdit,
         },

--- a/assets/js/views/order/distribution/BulkDistributionLineItemForm.vue
+++ b/assets/js/views/order/distribution/BulkDistributionLineItemForm.vue
@@ -14,19 +14,20 @@
             </div>
             <lineitemformrow
                 v-for="(lineItem, index) in lineItems"
+                v-show="!filterText || filterResults.includes(lineItem.client.id)"
                 :key="lineItem.client.id"
                 v-model="lineItems[index]"
                 :editable="editable"
                 :partner-type="partnerType"
-                v-show="!filterText || filterResults.includes(lineItem.client.id)"
             />
         </div>
     </div>
 </template>
 
 <script>
-    import BulkDistributionLineItemFormRow from './BulkDistributionLineItemFormRow';
-    export default {
+import BulkDistributionLineItemFormRow from './BulkDistributionLineItemFormRow';
+
+export default {
         components: {
             'lineitemformrow' : BulkDistributionLineItemFormRow
         },

--- a/assets/js/views/partner/PartnerLocationEditTab.vue
+++ b/assets/js/views/partner/PartnerLocationEditTab.vue
@@ -1,6 +1,9 @@
 <template>
     <div>
-        <form role="form" class="row">
+        <form
+            role="form"
+            class="row"
+        >
             <div class="col-md-6">
                 <div class="box box-info">
                     <div class="box-header with-border">
@@ -147,11 +150,11 @@
 
 
 <script>
-    import AddressFormFields from '../../components/AddressFormFields.vue';
-    import ContactFormFields from '../../components/ContactFormFields.vue';
-    import OptionListEntity from '../../components/OptionListEntity.vue';
+import AddressFormFields from '../../components/AddressFormFields.vue';
+import ContactFormFields from '../../components/ContactFormFields.vue';
+import OptionListEntity from '../../components/OptionListEntity.vue';
 
-    export default {
+export default {
         name: 'PartnerLocationEditTab',
         components: {
             AddressFormFields,

--- a/assets/js/views/product/ProductCategoryView.vue
+++ b/assets/js/views/product/ProductCategoryView.vue
@@ -37,7 +37,10 @@
                                 color="#3c8dbc"
                             />
                         </div>
-                        <table v-else class="table table-hover">
+                        <table
+                            v-else
+                            class="table table-hover"
+                        >
                             <thead>
                                 <tr>
                                     <th>{{ name }} ID</th>
@@ -74,9 +77,9 @@
 </template>
 
 <script>
-    import PulseLoader from "vue-spinner/src/PulseLoader";
+import PulseLoader from "vue-spinner/src/PulseLoader";
 
-    export default {
+export default {
         components: {
             PulseLoader,
         },

--- a/assets/js/views/warehouse/WarehouseList.vue
+++ b/assets/js/views/warehouse/WarehouseList.vue
@@ -37,7 +37,10 @@
                                 color="#3c8dbc"
                             />
                         </div>
-                        <table v-else class="table table-hover">
+                        <table
+                            v-else
+                            class="table table-hover"
+                        >
                             <thead>
                                 <tr>
                                     <th>Warehouse ID</th>
@@ -72,9 +75,9 @@
 </template>
 
 <script>
-    import PulseLoader from "vue-spinner/src/PulseLoader";
+import PulseLoader from "vue-spinner/src/PulseLoader";
 
-    export default {
+export default {
         components: {
             PulseLoader,
         },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "@vue/test-utils": "^1.0.0-beta.29",
         "axios": "^0.18.1",
         "babel-core": "^7.0.0-bridge.0",
+        "babel-eslint": "^10.1.0",
         "babel-jest": "^24.9.0",
         "bootstrap-sass": "^3.3.7",
         "bootstrap-tooltip": "^3.1.1",

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -296,7 +296,13 @@ class Client extends CoreEntity
             $stateMachine->apply($this, $transition);
         } catch (LogicException $ex) {
             // TODO log this instead
-            throw new \Exception(sprintf('%s is not a valid transition at this time. Exception thrown: %s', $transition, $ex->getMessage()));
+            throw new \Exception(
+                sprintf(
+                    '%s is not a valid transition at this time. Exception thrown: %s',
+                    $transition,
+                    $ex->getMessage()
+                )
+            );
         }
     }
 

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -240,7 +240,13 @@ class Partner extends StorageLocation
             $stateMachine->apply($this, $transition);
         } catch (LogicException $ex) {
             // TODO log this instead
-            throw new \Exception(sprintf('%s is not a valid transition at this time. Exception thrown: %s', $transition, $ex->getMessage()));
+            throw new \Exception(
+                sprintf(
+                    '%s is not a valid transition at this time. Exception thrown: %s',
+                    $transition,
+                    $ex->getMessage()
+                )
+            );
         }
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -234,7 +234,9 @@ class User extends CoreEntity implements UserInterface
     public function getActivePartner(): ?Partner
     {
         if (!$this->activePartner) {
-            if ($this->isAdmin()) return null;
+            if ($this->isAdmin()) {
+                return null;
+            }
 
             $this->activePartner = $this->partners->first();
         }

--- a/src/Transformers/UserTransformer.php
+++ b/src/Transformers/UserTransformer.php
@@ -38,7 +38,9 @@ class UserTransformer extends TransformerAbstract
 
     public function includeActivePartner(User $user)
     {
-        if (!$user->getActivePartner()) return null;
+        if (!$user->getActivePartner()) {
+            return null;
+        }
 
         return $this->item($user->getActivePartner(), new PartnerTransformer());
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
+  integrity sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==
+  dependencies:
+    "@babel/highlight" "^7.10.1"
+
 "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -54,6 +61,16 @@
     lodash "^4.17.11"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.10.1":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
+  integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
+  dependencies:
+    "@babel/types" "^7.10.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
 
 "@babel/generator@^7.4.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
@@ -127,12 +144,28 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz#92bd63829bfc9215aca9d9defa85f56b539454f4"
+  integrity sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.1"
+    "@babel/template" "^7.10.1"
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz#7303390a81ba7cb59613895a192b93850e373f7d"
+  integrity sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==
+  dependencies:
+    "@babel/types" "^7.10.1"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -220,12 +253,24 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-split-export-declaration@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz#c6f4be1cbc15e3a868e4c64a17d5d31d754da35f"
+  integrity sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==
+  dependencies:
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-split-export-declaration@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
   integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
   dependencies:
     "@babel/types" "^7.4.4"
+
+"@babel/helper-validator-identifier@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
+  integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
@@ -264,10 +309,24 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.1.tgz#841d098ba613ba1a427a2b383d79e35552c38ae0"
+  integrity sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.1"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
   version "7.6.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
   integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
+
+"@babel/parser@^7.10.1", "@babel/parser@^7.7.0":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
+  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
 "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
@@ -672,6 +731,15 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
+"@babel/template@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.1.tgz#e167154a94cb5f14b28dc58f5356d2162f539811"
+  integrity sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==
+  dependencies:
+    "@babel/code-frame" "^7.10.1"
+    "@babel/parser" "^7.10.1"
+    "@babel/types" "^7.10.1"
+
 "@babel/template@^7.4.0", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -711,6 +779,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.0":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
+  integrity sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.1"
+    "@babel/generator" "^7.10.1"
+    "@babel/helper-function-name" "^7.10.1"
+    "@babel/helper-split-export-declaration" "^7.10.1"
+    "@babel/parser" "^7.10.1"
+    "@babel/types" "^7.10.1"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
@@ -718,6 +801,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.7.0":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
+  integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.1"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
@@ -1746,6 +1838,18 @@ babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -8655,6 +8759,13 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.12.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
This fixes #108 

**Note:** This PR will be easier to review commit-by-commit since each commit can stand alone and takes care of a specific kind of fix.

### PHP

PHP in the master branch was not getting built by the CI due to a lint error.
This PR fixes:
* Warning about line length for some exceptions we were throwing. See: fd809b9be5

### JS

JS in the master branch was not getting built by the CI due to several eslint errors.

This PR fixes:
* Errors and Warnings via `yarn lint --fix`
* Errors via removing unused components from `UserEdit`. See: 6f90dc4
* A conditional-chaining error because eslint doesn't know what conditional-chaining is
   * It knows what conditional-chaining is now. See: 35ca85797c66
* Error about mixing `v-for` and `v-if`. The fix actually simplifies the code, so yay! See: 1e438edcab4983

The remaining `v-for` mixed with `v-if` eslint error: 
![image](https://user-images.githubusercontent.com/1981351/84272062-8e094080-aaf2-11ea-89da-435d3b480f35.png)