### PR TITLE
85 client expiration transitions

### DIFF
--- a/assets/js/views/client/ClientEdit.vue
+++ b/assets/js/views/client/ClientEdit.vue
@@ -14,12 +14,12 @@
                 >
                     <li
                         v-for="enabledTransition in client.workflow.enabledTransitions.sort()"
-                        :key="enabledTransition"
+                        :key="enabledTransition.transition"
                     >
                         <a
-                            @click.prevent="doTransition(enabledTransition)"
+                            @click.prevent="doTransition(enabledTransition.transition)"
                         >
-                            <i class="fa fa-arrow-circle-right" />{{ enabledTransition | statusFormat }}
+                            <i class="fa fa-arrow-circle-right" />{{ enabledTransition.title }}
                         </a>
                     </li>
                 </ul>

--- a/assets/js/views/partner/PartnerEdit.vue
+++ b/assets/js/views/partner/PartnerEdit.vue
@@ -14,12 +14,12 @@
                 >
                     <li
                         v-for="enabledTransition in partner.workflow.enabledTransitions.sort()"
-                        :key="enabledTransition"
+                        :key="enabledTransition.transition"
                     >
                         <a
-                            @click.prevent="doTransition(enabledTransition)"
+                            @click.prevent="doTransition(enabledTransition.transition)"
                         >
-                            <i class="fa fa-arrow-circle-right" />{{ enabledTransition | statusFormat }}
+                            <i class="fa fa-arrow-circle-right" />{{ enabledTransition.title }}
                         </a>
                     </li>
                 </ul>

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/validator": "*",
         "symfony/webpack-encore-bundle": "^1.0",
         "symfony/workflow": "*",
-        "symfony/yaml": "*"
+        "symfony/yaml": "*",
+        "zenstruck/schedule-bundle": "^1.0"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adeefeccac58616f432dac32e444ba2f",
+    "content-hash": "fb004d60c197e0ab0fb5a282e9f2f56a",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1305,6 +1305,60 @@
                 "sql"
             ],
             "time": "2020-05-29T18:32:49+00:00"
+        },
+        {
+            "name": "dragonmantank/cron-expression",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dragonmantank/cron-expression.git",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris@ctankersley.com",
+                    "homepage": "https://github.com/dragonmantank"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "time": "2019-03-31T00:38:28+00:00"
         },
         {
             "name": "egulias/email-validator",
@@ -6502,6 +6556,74 @@
             ],
             "abandoned": "laminas/laminas-eventmanager",
             "time": "2018-04-25T15:33:34+00:00"
+        },
+        {
+            "name": "zenstruck/schedule-bundle",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zenstruck/schedule-bundle.git",
+                "reference": "76636e5d301957c36a7c29129f11cada3b76663c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zenstruck/schedule-bundle/zipball/76636e5d301957c36a7c29129f11cada3b76663c",
+                "reference": "76636e5d301957c36a7c29129f11cada3b76663c",
+                "shasum": ""
+            },
+            "require": {
+                "dragonmantank/cron-expression": "^2.3",
+                "php": "^7.2",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "require-dev": {
+                "lorisleiva/cron-translator": "^0.1.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+                "psr/log": "^1.1",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/mailer": "^4.4|^5.0",
+                "symfony/phpunit-bridge": "^5.0",
+                "symfony/process": "^4.2|^5.0"
+            },
+            "suggest": {
+                "lorisleiva/cron-translator": "Displays human readable cron expression in schedule:list",
+                "symfony/http-client": "Allows usage of ping* extensions",
+                "symfony/lock": "Allows usage of withoutOverlapping and onSingleServer extensions (4.4+)",
+                "symfony/mailer": "Allows usage of email* extensions (4.4+)",
+                "symfony/process": "Allows usage of ProcessTask (4.2+)"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zenstruck\\ScheduleBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Bond",
+                    "email": "kevinbond@gmail.com"
+                }
+            ],
+            "description": "Schedule Cron jobs (commands/callbacks/bash scripts) within your Symfony application.",
+            "homepage": "https://github.com/zenstruck/schedule-bundle",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "time": "2020-05-07T15:39:01+00:00"
         }
     ],
     "packages-dev": [

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,4 +18,5 @@ return [
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Liip\TestFixturesBundle\LiipTestFixturesBundle::class => ['dev' => true, 'test' => true],
+    Zenstruck\ScheduleBundle\ZenstruckScheduleBundle::class => ['all' => true],
 ];

--- a/config/packages/workflow.php
+++ b/config/packages/workflow.php
@@ -28,22 +28,28 @@ $container->loadFromExtension('framework', [
                 Partner::STATUS_INACTIVE,
             ],
             'transitions' => [
-                'submit' => [
+                Partner::TRANSITION_SUBMIT => [
                     'from' => [
                         Partner::STATUS_START,
                         Partner::STATUS_APPLICATION_PENDING_PRIORITY,
                         Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_APPLICATION_PENDING,
+                    'metadata' => [
+                        'title' => 'Submit'
+                    ],
                 ],
-                'submit_priority' => [
+                Partner::TRANSITION_SUBMIT_PRIORITY => [
                     'from' => [
                         Partner::STATUS_APPLICATION_PENDING,
                         Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_APPLICATION_PENDING_PRIORITY,
+                    'metadata' => [
+                        'title' => 'Submit (Priority)'
+                    ],
                 ],
-                'activate' => [
+                Partner::TRANSITION_ACTIVATE => [
                     'from' => [
                         Partner::STATUS_APPLICATION_PENDING,
                         Partner::STATUS_APPLICATION_PENDING_PRIORITY,
@@ -52,8 +58,11 @@ $container->loadFromExtension('framework', [
                         Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_ACTIVE,
+                    'metadata' => [
+                        'title' => 'Activate'
+                    ],
                 ],
-                'flag_for_review' => [
+                Partner::TRANSITION_FLAG_FOR_REVIEW => [
                     'from' => [
                         Partner::STATUS_APPLICATION_PENDING,
                         Partner::STATUS_APPLICATION_PENDING_PRIORITY,
@@ -62,8 +71,11 @@ $container->loadFromExtension('framework', [
                         Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_NEEDS_PROFILE_REVIEW,
+                    'metadata' => [
+                        'title' => 'Flag for Review'
+                    ],
                 ],
-                'flag_for_review_past_due' => [
+                Partner::TRANSITION_FLAG_FOR_REVIEW_PAST_DUE => [
                     'from' => [
                         Partner::STATUS_APPLICATION_PENDING,
                         Partner::STATUS_APPLICATION_PENDING_PRIORITY,
@@ -71,9 +83,12 @@ $container->loadFromExtension('framework', [
                         Partner::STATUS_NEEDS_PROFILE_REVIEW,
                         Partner::STATUS_INACTIVE,
                     ],
-                    'to' => Partner::STATUS_REVIEW_PAST_DUE,
+                    'metadata' => [
+                        'title' => 'Flag for Review Past Due'
+                    ],
+                   'to' => Partner::STATUS_REVIEW_PAST_DUE,
                 ],
-                'deactivate' => [
+                Partner::TRANSITION_DEACTIVATE => [
                     'from' => [
                         Partner::STATUS_APPLICATION_PENDING,
                         Partner::STATUS_APPLICATION_PENDING_PRIORITY,
@@ -82,6 +97,9 @@ $container->loadFromExtension('framework', [
                         Partner::STATUS_REVIEW_PAST_DUE,
                     ],
                     'to' => Partner::STATUS_INACTIVE,
+                    'metadata' => [
+                        'title' => 'Deactivate'
+                    ],
                 ],
             ],
         ],
@@ -106,7 +124,7 @@ $container->loadFromExtension('framework', [
                 Client::STATUS_DUPLICATE_INACTIVE,
             ],
             'transitions' => [
-                'activate' => [
+                Client::TRANSITION_ACTIVATE => [
                     'from' => [
                         Client::STATUS_CREATION,
                         Client::STATUS_INACTIVE,
@@ -114,8 +132,11 @@ $container->loadFromExtension('framework', [
                         Client::STATUS_DUPLICATE_INACTIVE,
                     ],
                     'to' => Client::STATUS_ACTIVE,
+                    'metadata' => [
+                        'title' => 'Activate'
+                    ],
                 ],
-                'deactivate' => [
+                Client::TRANSITION_DEACTIVATE => [
                     'from' => [
                         Client::STATUS_CREATION,
                         Client::STATUS_ACTIVE,
@@ -123,8 +144,11 @@ $container->loadFromExtension('framework', [
                         Client::STATUS_DUPLICATE_INACTIVE,
                     ],
                     'to' => Client::STATUS_INACTIVE,
+                    'metadata' => [
+                        'title' => 'Deactivate'
+                    ],
                 ],
-                'reach_limit' => [
+                Client::TRANSITION_EXPIRE => [
                     'from' => [
                         Client::STATUS_CREATION,
                         Client::STATUS_ACTIVE,
@@ -132,8 +156,11 @@ $container->loadFromExtension('framework', [
                         Client::STATUS_DUPLICATE_INACTIVE,
                     ],
                     'to' => Client::STATUS_LIMIT_REACHED,
+                    'metadata' => [
+                        'title' => 'Expire Client'
+                    ],
                 ],
-                'duplicate_(inactivate)' => [
+                Client::TRANSITION_DUPLICATE_INACTIVE => [
                     'from' => [
                         Client::STATUS_CREATION,
                         Client::STATUS_ACTIVE,
@@ -141,6 +168,9 @@ $container->loadFromExtension('framework', [
                         Client::STATUS_LIMIT_REACHED,
                     ],
                     'to' => Client::STATUS_DUPLICATE_INACTIVE,
+                    'metadata' => [
+                        'title' => 'Duplicate (inactivate)'
+                    ],
                 ],
             ],
         ],

--- a/src/Command/ClientExpirationCommand.php
+++ b/src/Command/ClientExpirationCommand.php
@@ -37,7 +37,12 @@ class ClientExpirationCommand extends Command
     {
         $this
             ->setDescription('Run the client expiration checks and transition expired clients. ')
-            ->addOption('force', null, InputOption::VALUE_NONE, 'Execute transitions on expired clients. Otherwise, actions will only be reported.')
+            ->addOption(
+                'force',
+                null,
+                InputOption::VALUE_NONE,
+                'Execute transitions on expired clients. Otherwise, actions will only be reported.'
+            )
         ;
     }
 
@@ -51,7 +56,7 @@ class ClientExpirationCommand extends Command
 
         $agedOutClients = $clientRepo->findAllActiveAgedOut();
 
-        $ageRows = array_map(function(Client $client) {
+        $ageRows = array_map(function (Client $client) {
             return [
                 (string) $client,
                 (string) $client->getPartner(),
@@ -62,7 +67,7 @@ class ClientExpirationCommand extends Command
 
         $maxDistributionClients = $clientRepo->findAllActiveMaxDistributions();
 
-        $distRows = array_map(function(Client $client) {
+        $distRows = array_map(function (Client $client) {
             return [
                 (string) $client,
                 (string) $client->getPartner(),
@@ -90,12 +95,18 @@ class ClientExpirationCommand extends Command
 
             $this->em->flush();
 
-            $io->success(sprintf('%d client(s) have been transitioned to "%s".', count($rows), Client::TRANSITION_EXPIRE));
+            $io->success(sprintf(
+                '%d client(s) have been transitioned to "%s".',
+                count($rows),
+                Client::TRANSITION_EXPIRE
+            ));
         } else {
-            $io->warning(sprintf('%d client(s) are queued for expiration. Use --force to update client statuses', count($rows)));
+            $io->warning(sprintf(
+                '%d client(s) are queued for expiration. Use --force to update client statuses',
+                count($rows)
+            ));
         }
 
         return 0;
     }
-
 }

--- a/src/Command/ClientExpirationCommand.php
+++ b/src/Command/ClientExpirationCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Client;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ClientExpirationCommand extends Command
+{
+    protected static $defaultName = 'app:client-expiration';
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Run the client expiration checks and transition expired clients. ')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Execute transitions on expired clients. Otherwise, actions will only be reported.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $force = $input->getOption('force') !== false;
+        $io = new SymfonyStyle($input, $output);
+        $clientRepo = $this->em->getRepository(Client::class);
+
+        $headers = ['Client', 'Partner', 'Expiration Reason', 'Expiration Date'];
+
+        $agedOutClients = $clientRepo->findAllActiveAgedOut();
+
+        $ageRows = array_map(function(Client $client) {
+            return [
+                (string) $client,
+                (string) $client->getPartner(),
+                'Age Expiration',
+                $client->getAgeExpiresAt()->format('Y-m-d'),
+            ];
+        }, $agedOutClients);
+
+        $maxDistributionClients = $clientRepo->findAllActiveMaxDistributions();
+
+        $distRows = array_map(function(Client $client) {
+            return [
+                (string) $client,
+                (string) $client->getPartner(),
+                'Distribution Expiration',
+                $client->getDistributionExpiresAt()->format('Y-m-d'),
+            ];
+        }, $maxDistributionClients);
+
+        $rows = array_merge($ageRows, $distRows);
+
+        $io->table($headers, array_merge($ageRows, $rows));
+
+        $io->warning(sprintf('%d client(s) will are queued for expiration.', count($rows)));
+
+        return 0;
+    }
+
+}

--- a/src/Command/ClientExpirationCommand.php
+++ b/src/Command/ClientExpirationCommand.php
@@ -68,7 +68,7 @@ class ClientExpirationCommand extends Command
 
         $io->table($headers, array_merge($ageRows, $rows));
 
-        $io->warning(sprintf('%d client(s) will are queued for expiration.', count($rows)));
+        $io->warning(sprintf('%d client(s) are queued for expiration.', count($rows)));
 
         return 0;
     }

--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -227,12 +227,15 @@ class ClientController extends BaseController
      */
     protected function getEnabledTransitions(Registry $workflowRegistry, Client $client): array
     {
-        $enabledTransitions = $workflowRegistry
-            ->get($client)
-            ->getEnabledTransitions($client);
+        $workflow = $workflowRegistry->get($client);
+        $enabledTransitions = $workflow->getEnabledTransitions($client);
 
-        return array_map(function (Transition $transition) {
-            return $transition->getName();
+        return array_map(function (Transition $transition) use ($workflow) {
+            $title = $workflow->getMetadataStore()->getTransitionMetadata($transition)['title'];
+            return [
+                'transition' => $transition->getName(),
+                'title' => $title
+            ];
         }, $enabledTransitions);
     }
 }

--- a/src/Controller/PartnerController.php
+++ b/src/Controller/PartnerController.php
@@ -184,12 +184,15 @@ class PartnerController extends BaseController
      */
     protected function getEnabledTransitions(Registry $workflowRegistry, Partner $partner): array
     {
-        $enabledTransitions = $workflowRegistry
-            ->get($partner)
-            ->getEnabledTransitions($partner);
+        $workflow = $workflowRegistry->get($partner);
+        $enabledTransitions = $workflow->getEnabledTransitions($partner);
 
-        return array_map(function (Transition $transition) {
-            return $transition->getName();
+        return array_map(function (Transition $transition) use ($workflow) {
+            $title = $workflow->getMetadataStore()->getTransitionMetadata($transition)['title'];
+            return [
+                'transition' => $transition->getName(),
+                'title' => $title
+            ];
         }, $enabledTransitions);
     }
 }

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -27,6 +27,12 @@ class Client extends CoreEntity
     public const STATUS_LIMIT_REACHED = 'LIMIT_REACHED';
     public const STATUS_DUPLICATE_INACTIVE = 'DUPLICATE_(INACTIVE)';
 
+    public const TRANSITION_ACTIVATE = 'ACTIVATE';
+    public const TRANSITION_DEACTIVATE = 'DEACTIVATE';
+    public const TRANSITION_EXPIRE = 'EXPIRE';
+    public const TRANSITION_DUPLICATE_INACTIVE = 'DUPLICATE';
+
+
     use Uuidable;
     use AttributedEntityTrait;
 

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -32,7 +32,6 @@ class Client extends CoreEntity
     public const TRANSITION_EXPIRE = 'EXPIRE';
     public const TRANSITION_DUPLICATE_INACTIVE = 'DUPLICATE';
 
-
     use Uuidable;
     use AttributedEntityTrait;
 

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -120,6 +120,11 @@ class Client extends CoreEntity
         $this->workflowRegistry = $workflowRegistry;
     }
 
+    public function __toString()
+    {
+        return sprintf('%s (%s)', $this->name, $this->getId());
+    }
+
     public function getName(): Name
     {
         return $this->name;

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -27,7 +27,7 @@ class Partner extends StorageLocation
     ];
 
     public const ROLE_VIEW_ALL = 'ROLE_PARTNER_VIEW_ALL';
-    public const ROLE_EDIT = 'ROLE_PARTNER_EDIT';
+    public const ROLE_EDIT_ALL = 'ROLE_PARTNER_EDIT_ALL';
     public const ROLE_MANAGE_OWN = 'ROLE_PARTNER_MANAGE_OWN';
 
     // State Machine Statuses
@@ -123,6 +123,11 @@ class Partner extends StorageLocation
         $this->users = new ArrayCollection();
         $this->status = self::STATUS_START;
         $this->workflowRegistry = $workflowRegistry;
+    }
+
+    public function __toString()
+    {
+        return sprintf('%s (%s)', $this->getTitle(), $this->id);
     }
 
     /**

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -47,6 +47,13 @@ class Partner extends StorageLocation
         self::STATUS_INACTIVE,
     ];
 
+    public const TRANSITION_SUBMIT = 'SUBMIT';
+    public const TRANSITION_SUBMIT_PRIORITY = 'SUBMIT_PRIORITY';
+    public const TRANSITION_ACTIVATE = 'ACTIVATE';
+    public const TRANSITION_FLAG_FOR_REVIEW = 'FLAG_FOR_REVIEW';
+    public const TRANSITION_FLAG_FOR_REVIEW_PAST_DUE = 'FLAG_FOR_REVIEW_PAST_DUE';
+    public const TRANSITION_DEACTIVATE = 'DEACTIVATE';
+
     /**
      * @var string
      *

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -78,4 +78,40 @@ class ClientRepository extends EntityRepository
     {
         $qb->join('c.partner', 'partner');
     }
+
+    /**
+     * Returns all clients that are currently active and their age expiration date has passed.
+     */
+    public function findAllActiveAgedOut()
+    {
+        $qb = $this->createQueryBuilder('c');
+
+        $qb->andWhere('c.status = :status')
+            ->setParameter('status', Client::STATUS_ACTIVE);
+
+        $now = new \DateTimeImmutable();
+
+        $qb->andWhere('c.ageExpiresAt < :now')
+            ->setParameter('now', $now);
+
+        return $qb->getQuery()->execute();
+    }
+
+    /**
+     * Returns all clients that are currently active and their age expiration date has passed.
+     */
+    public function findAllActiveMaxDistributions()
+    {
+        $qb = $this->createQueryBuilder('c');
+
+        $qb->andWhere('c.status = :status')
+            ->setParameter('status', Client::STATUS_ACTIVE);
+
+        $now = new \DateTimeImmutable();
+
+        $qb->andWhere('c.distributionExpiresAt < :now')
+            ->setParameter('now', $now);
+
+        return $qb->getQuery()->execute();
+    }
 }

--- a/src/Schedule/ClientExpirationSchedule.php
+++ b/src/Schedule/ClientExpirationSchedule.php
@@ -1,7 +1,6 @@
 <?php
 namespace App\Schedule;
 
-
 use Zenstruck\ScheduleBundle\Schedule;
 use Zenstruck\ScheduleBundle\Schedule\ScheduleBuilder;
 

--- a/src/Schedule/ClientExpirationSchedule.php
+++ b/src/Schedule/ClientExpirationSchedule.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Schedule;
+
+
+use Zenstruck\ScheduleBundle\Schedule;
+use Zenstruck\ScheduleBundle\Schedule\ScheduleBuilder;
+
+class ClientExpirationSchedule implements ScheduleBuilder
+{
+    public function buildSchedule(Schedule $schedule): void
+    {
+        $schedule
+            ->timezone('UTC')
+            ->environments('prod', 'stage')
+        ;
+
+        $schedule->addCommand('app:client-expiration --force')
+            ->description('Run client expiration job.')
+            ->daily()
+            ->at(6)
+        ;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -96,6 +96,9 @@
     "doctrine/sql-formatter": {
         "version": "1.1.0"
     },
+    "dragonmantank/cron-expression": {
+        "version": "v2.3.0"
+    },
     "egulias/email-validator": {
         "version": "2.1.9"
     },
@@ -589,5 +592,8 @@
     },
     "zendframework/zend-eventmanager": {
         "version": "3.2.1"
+    },
+    "zenstruck/schedule-bundle": {
+        "version": "v1.0.0"
     }
 }


### PR DESCRIPTION
Closes #85 

This PR creates a command that will find all active clients and transition them to the Expired status if they are past an expiration date in the entity. This also uses the zenstruck scheduler to schedule that command to run daily overnight.

## Extras
I refactored a bit of the workflow response so that we can control the frontend user visible title of the transitions so that we can make changes to that easily if the bank needs it, and we don't have to rely on title casing the machine names. I also used constants for the transition machine name so that we can control transitions and states in the entity.