### PR TITLE
119 Adjustment and Transfer Order Voter

### DIFF
--- a/src/Controller/AdjustmentOrderController.php
+++ b/src/Controller/AdjustmentOrderController.php
@@ -6,6 +6,7 @@ use App\Entity\Orders\AdjustmentOrder;
 use App\Entity\Orders\AdjustmentOrderLineItem;
 use App\Entity\StorageLocation;
 use App\Transformers\AdjustmentOrderTransformer;
+use App\Security\AdjustmentOrderVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -50,8 +51,7 @@ class AdjustmentOrderController extends OrderController
 
         $order->applyChangesFromArray($params);
 
-        // TODO: get permissions working (#1)
-        // $this->checkEditPermissions($order);
+        $this->denyAccessUnlessGranted(AdjustmentOrderVoter::EDIT, $order);
 
         $this->getEm()->persist($order);
         $this->getEm()->flush();
@@ -76,6 +76,8 @@ class AdjustmentOrderController extends OrderController
         $order = $this->getOrder($id);
 
         $this->checkEditable($order);
+
+        $this->denyAccessUnlessGranted(AdjustmentOrderVoter::EDIT, $order);
 
         if ($params['storageLocation']['id']) {
             $newLocation = $this->getEm()->find(StorageLocation::class, $params['storageLocation']['id']);

--- a/src/Controller/SupplyOrderController.php
+++ b/src/Controller/SupplyOrderController.php
@@ -8,6 +8,7 @@ use App\Entity\Supplier;
 use App\Entity\SupplierAddress;
 use App\Entity\Warehouse;
 use App\Transformers\SupplyOrderTransformer;
+use App\Security\SupplyOrderVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -61,8 +62,7 @@ class SupplyOrderController extends OrderController
 
         $order->applyChangesFromArray($params);
 
-        // TODO: get permissions working (#1)
-        // $this->checkEditPermissions($order);
+        $this->denyAccessUnlessGranted(SupplyOrderVoter::EDIT, $order);
 
         $this->getEm()->persist($order);
         $this->getEm()->flush();
@@ -86,8 +86,7 @@ class SupplyOrderController extends OrderController
         /** @var \App\Entity\Orders\SupplyOrder $order */
         $order = $this->getOrder($id);
 
-        // TODO: get permissions working (#1)
-        // $this->checkEditPermissions($order);
+        $this->denyAccessUnlessGranted(SupplyOrderVoter::EDIT, $order);
 
         $this->checkEditable($order);
         

--- a/src/Controller/TransferOrdersController.php
+++ b/src/Controller/TransferOrdersController.php
@@ -6,6 +6,7 @@ use App\Entity\Orders\TransferOrder;
 use App\Entity\Orders\TransferOrderLineItem;
 use App\Entity\StorageLocation;
 use App\Transformers\TransferOrderTransformer;
+use App\Security\TransferOrderVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -57,8 +58,7 @@ class TransferOrdersController extends OrderController
 
         $order->validate();
 
-        // TODO: get permissions working (#1)
-        // $this->checkEditPermissions($order);
+        $this->denyAccessUnlessGranted(TransferOrderVoter::EDIT, $order);
 
         $this->getEm()->persist($order);
         $this->getEm()->flush();
@@ -85,9 +85,7 @@ class TransferOrdersController extends OrderController
 
         $this->checkEditable($order);
 
-        // TODO: get permissions working (#1)
-        // $this->checkEditPermissions($order);
-
+        $this->denyAccessUnlessGranted(TransferOrderVoter::EDIT, $order);
 
         if ($params['sourceLocation']['id']) {
             $newLocation = $this->getEm()->find(StorageLocation::class, $params['sourceLocation']['id']);

--- a/src/Entity/Orders/SupplyOrder.php
+++ b/src/Entity/Orders/SupplyOrder.php
@@ -21,8 +21,8 @@ class SupplyOrder extends Order
     const STATUS_ORDERED = "ORDERED";
     const STATUS_RECEIVED = "RECEIVED";
 
-    const ROLE_VIEW = "ROLE_SUPPLY_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_SUPPLY_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_SUPPLY_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_SUPPLY_ORDER_EDIT";
 
     /**
      * @var Supplier $supplier

--- a/src/Security/AdjustmentOrderVoter.php
+++ b/src/Security/AdjustmentOrderVoter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Orders\AdjustmentOrder;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class AdjustmentOrderVoter extends Voter
+{
+    public const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
+
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
+
+        if (!$subject instanceof AdjustmentOrder) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($subject, $user);
+            case self::EDIT:
+                return $this->canEdit($subject, $user);
+            default:
+                throw new \LogicException('This code should not be reached!');
+        }
+    }
+
+    private function canView(AdjustmentOrder $adjustmentOrder, User $user)
+    {
+        if ($this->canEdit($adjustmentOrder, $user)) {
+            return true;
+        }
+
+        if ($user->hasRole(AdjustmentOrder::ROLE_VIEW)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canEdit(AdjustmentOrder $adjustmentOrder, User $user)
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        if ($user->hasRole(AdjustmentOrder::ROLE_EDIT)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Security/SupplyOrderVoter.php
+++ b/src/Security/SupplyOrderVoter.php
@@ -9,63 +9,63 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class SupplyOrderVoter extends Voter
 {
-	public const VIEW = 'VIEW';
-	public const EDIT = 'EDIT';
+    public const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
 
-	protected function supports($attribute, $subject)
-	{
-		if (!in_array($attribute, [self::VIEW, self::EDIT])) {
-			return false;
-		}
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
 
-		if (!$subject instanceof SupplyOrder) {
-			return false;
-		}
+        if (!$subject instanceof SupplyOrder) {
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
-	{
-		$user = $token->getUser();
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
 
-		if (!$user instanceof User) {
-			return false;
-		}
+        if (!$user instanceof User) {
+            return false;
+        }
 
-		switch ($attribute) {
-			case self::VIEW:
-				return $this->canView($subject, $user);
-			case self::EDIT:
-				return $this->canEdit($subject, $user);
-			default:
-				throw new \LogicException('This code should not be reached!');
-		}
-	}
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($subject, $user);
+            case self::EDIT:
+                return $this->canEdit($subject, $user);
+            default:
+                throw new \LogicException('This code should not be reached!');
+        }
+    }
 
-	private function canView(SupplyOrder $supplyOrder, User $user)
-	{
-		if ($this->canEdit($supplyOrder, $user)) {
-			return true;
-		}
+    private function canView(SupplyOrder $supplyOrder, User $user)
+    {
+        if ($this->canEdit($supplyOrder, $user)) {
+            return true;
+        }
 
-		if ($user->hasRole(SupplyOrder::ROLE_VIEW)) {
-			return true;
-		}
+        if ($user->hasRole(SupplyOrder::ROLE_VIEW)) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	private function canEdit(SupplyOrder $supplyOrder, User $user)
-	{
-		if ($user->isAdmin()) {
-			return true;
-		}
+    private function canEdit(SupplyOrder $supplyOrder, User $user)
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
 
-		if ($user->hasRole(SupplyOrder::ROLE_EDIT)) {
-			return true;
-		}
+        if ($user->hasRole(SupplyOrder::ROLE_EDIT)) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 }

--- a/src/Security/SupplyOrderVoter.php
+++ b/src/Security/SupplyOrderVoter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Orders\SupplyOrder;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class SupplyOrderVoter extends Voter
+{
+	public const VIEW = 'VIEW';
+	public const EDIT = 'EDIT';
+
+	protected function supports($attribute, $subject)
+	{
+		if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+			return false;
+		}
+
+		if (!$subject instanceof SupplyOrder) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+	{
+		$user = $token->getUser();
+
+		if (!$user instanceof User) {
+			return false;
+		}
+
+		switch ($attribute) {
+			case self::VIEW:
+				return $this->canView($subject, $user);
+			case self::EDIT:
+				return $this->canEdit($subject, $user);
+			default:
+				throw new \LogicException('This code should not be reached!');
+		}
+	}
+
+	private function canView(SupplyOrder $supplyOrder, User $user)
+	{
+		if ($this->canEdit($supplyOrder, $user)) {
+			return true;
+		}
+
+		if ($user->hasRole(SupplyOrder::ROLE_VIEW)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private function canEdit(SupplyOrder $supplyOrder, User $user)
+	{
+		if ($user->isAdmin()) {
+			return true;
+		}
+
+		if ($user->hasRole(SupplyOrder::ROLE_EDIT)) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Security/TransferOrderVoter.php
+++ b/src/Security/TransferOrderVoter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\Orders\AdjustmentOrder;
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class TransferOrderVoter extends Voter
+{
+    public const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
+
+    protected function supports($attribute, $subject)
+    {
+        if (!in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
+
+        if (!$subject instanceof TransferOrder) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($subject, $user);
+            case self::EDIT:
+                return $this->canEdit($subject, $user);
+            default:
+                throw new \LogicException('This code should not be reached!');
+        }
+    }
+
+    private function canView(TransferOrder $transferOrder, User $user)
+    {
+        if ($this->canEdit($transferOrder, $user)) {
+            return true;
+        }
+
+        if ($user->hasRole(TransferOrder::ROLE_VIEW)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function canEdit(TransferOrder $transferOrder, User $user)
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        if ($user->hasRole(TransferOrder::ROLE_EDIT)) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
@akoebbe The resulting behavior is that when clicked, `Adjustments > Stock Changes` and `Adjustments > Transfer Orders` in the navigation, simply do nothing, which isn't as user-friendly as I'm sure we'd like it to be. Just a thought! Thanks again!