### PR TITLE
Use total for pagination info when less than page limit

### DIFF
--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -31,8 +31,8 @@ class ClientController extends BaseController
 //        $this->checkViewPermissions($clients);
 
         $sort = $request->get('sort') ? explode('|', $request->get('sort')) : null;
-        $page = $request->get('page', 1);
-        $limit = $request->get('per_page', 10);
+        $page = (int) $request->get('page', 1);
+        $limit = (int) $request->get('per_page', 10);
 
         $params = $this->buildFilterParams($request);
 
@@ -44,18 +44,18 @@ class ClientController extends BaseController
             $params
         );
 
-        $total = $this->getRepository()->findAllCount($params);
+        $total = (int) $this->getRepository()->findAllCount($params);
 
         $meta = [
             'pagination' => [
-                'total' => (int) $total,
-                'per_page' => (int) $limit,
-                'current_page' => (int) $page,
+                'total' => $total,
+                'per_page' => $limit,
+                'current_page' => $page,
                 'last_page' => ceil($total / $limit),
                 'next_page_url' => null,
                 'prev_page_url' => null,
                 'from' => (($page - 1) * $limit) + 1,
-                'to' => ($page * $limit),
+                'to' => min($page * $limit, $total),
             ]
         ];
 


### PR DESCRIPTION
After reviewing the vue library that creates the table info, I realized the "to" value was a pass-through from the API response. I updated the controller to use the smaller value between the page limit or total found. I considered if there should be a factory for the pagination meta, as this would apply to all API endpoints that provide it.

Resolves #111. 

How it used to look:
![image](https://user-images.githubusercontent.com/17500494/86951748-9071b100-c117-11ea-95d2-473630938635.png)

How it looks now:
![image](https://user-images.githubusercontent.com/17500494/86951820-a97a6200-c117-11ea-8b87-f5e743e04f97.png)
