### PR TITLE
#139 - Error saving supply orders

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -22,3 +22,7 @@ doctrine:
                 dir: "%kernel.root_dir%/../vendor/gedmo/doctrine-extensions/lib/Gedmo/Loggable/Entity"
                 alias: GedmoLoggable # (optional) it will default to the name set for the mapping
                 is_bundle: false
+        filters:
+            softdeleteable:
+                class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter
+                enabled: true

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -240,7 +240,7 @@ class OrderController extends BaseController
     protected function processLineItems(Order $order, $lineItemsArray)
     {
         foreach ($lineItemsArray as $lineItemArray) {
-            if (!$lineItemArray['id'] && (!$lineItemArray['product']['id'] || !$lineItemArray['quantity'])) {
+            if (!isset($lineItemArray['id']) && (!$lineItemArray['product']['id'] || !$lineItemArray['quantity'])) {
                 continue;
             }
 


### PR DESCRIPTION
Closes #139 

Fixed how the line item processor dealt with empty IDs

Also found that the soft delete extension was not fully configured. The doctrine filter was not set up and therefore deleted items still showed up.
