### PR TITLE
74 Add help text property for attribute fields

### DIFF
--- a/assets/js/components/AttributesEditForm.vue
+++ b/assets/js/components/AttributesEditForm.vue
@@ -9,43 +9,51 @@
                     v-if="attribute.displayInterface === 'TOGGLE'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
                 <YesNoRadioField
                     v-else-if="attribute.displayInterface === 'YES_NO_RADIO'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
                 <DateField
                     v-else-if="attribute.displayInterface === 'DATETIME'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
                 <NumberField
                     v-else-if="attribute.displayInterface === 'NUMBER'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
                 <OptionListApi
                     v-else-if="attribute.displayInterface === 'SELECT_SINGLE'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                     :preloaded-options="attribute.options"
                 />
                 <RadioField
                     v-else-if="attribute.displayInterface === 'RADIO'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                     :preloaded-options="attribute.options"
                 />
                 <TextareaField
                     v-else-if="attribute.displayInterface === 'TEXTAREA'"
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
                 <TextField
                     v-else
                     v-model="attribute.value"
                     :label="attribute.label"
+                    :helpText="attribute.helpText"
                 />
             </div>
         </form>

--- a/assets/js/components/DateField.vue
+++ b/assets/js/components/DateField.vue
@@ -1,7 +1,12 @@
 <template>
     <div class="form-group">
         <label v-text="label" />
-
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <div class="input-group date">
             <div class="input-group-addon">
                 <i class="fa fa-calendar" />
@@ -22,7 +27,8 @@
         name: 'DateField',
         props: {
             value: { type: String, required: true },
-            label: { required: false, type: String, default: 'Date:' },
+            label: { type: String, required: false, default: 'Date:' },
+            helpText: { type: String, required: false, default: "" },
             format: { type: String, default: 'MM/DD/YYYY'},
             timezone: { type: String, required: false },
         },

--- a/assets/js/components/NumberField.vue
+++ b/assets/js/components/NumberField.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="form-group">
         <label v-text="label" />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <input
             :value="value"
             type="number"
@@ -15,8 +21,9 @@
     export default {
         name: 'NumberField',
         props: {
-            label: { required: true, type: String },
             value: { type: String, required: true },
+            label: { type: String, required: true },
+            helpText: { type: String, requird: false, default: "" },
             placeholder: { type: [String,Number] },
         }
     }

--- a/assets/js/components/OptionListApi.vue
+++ b/assets/js/components/OptionListApi.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="form-group">
         <label v-text="label" />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <select
             v-if="!groupProperty"
             v-chosen
@@ -56,6 +62,7 @@
         props: {
             value: { type: String, default: () => "" },
             label: { type: String },
+            helpText: { type: String, requird: false, default: "" },
             apiPath: { type: String },
             preloadedOptions: { type: Array, default: function() {return []}},
             displayProperty: { type: String, default: 'name'},

--- a/assets/js/components/RadioField.vue
+++ b/assets/js/components/RadioField.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="form-group">
         <label v-text="label" />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <div
             v-for="option in options"
             :key="option.id"
@@ -25,6 +31,7 @@
         props: {
             value: { type: String, required: true },
             label: { type: String },
+            helpText: { type: String, requird: false, default: "" },
             displayProperty: { type: String, default: 'name'},
             displayTextFn: { type: Function },
             preloadedOptions: { type: Array, default: function() {return []}},

--- a/assets/js/components/TextField.vue
+++ b/assets/js/components/TextField.vue
@@ -4,6 +4,12 @@
             v-if="label"
             v-text="label"
         />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <input
             :value="value"
             type="text"
@@ -20,7 +26,8 @@
         props: {
             label: { type: [String, Boolean], default: false },
             value: { type: String, required: true },
-            placeholder: { type: String, required: false, default: "" }
+            placeholder: { type: String, required: false, default: "" },
+            helpText: { type: String, required: false, default: "" },
         }
     }
 </script>

--- a/assets/js/components/TextareaField.vue
+++ b/assets/js/components/TextareaField.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="form-group">
         <label v-text="label" />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <textarea
             :value="value"
             class="form-control"
@@ -13,8 +19,9 @@
     export default {
         name: 'TextareaField',
         props: {
-            label: { required: true, type: String },
-            value: { type: String, required: true }
+            value: { type: String, required: true },
+            label: { type: String, required: true },
+            helpText: { type: String, requird: false, default: "" },
         }
     }
 </script>

--- a/assets/js/components/ToggleField.vue
+++ b/assets/js/components/ToggleField.vue
@@ -7,6 +7,12 @@
                 @change="$emit('input', $event.target.checked)"
             > {{ label }}
         </label>
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
     </div>
 </template>
 
@@ -14,8 +20,9 @@
     export default {
         name: 'BooleanField',
         props: {
-            label: { required: true, type: String },
-            value: { type: Boolean, required: true }
+            label: { type: String, required: true },
+            value: { type: Boolean, required: true },
+            helpText: { type: String, required: false, default: "" },
         }
     }
 </script>

--- a/assets/js/components/YesNoRadioField.vue
+++ b/assets/js/components/YesNoRadioField.vue
@@ -4,6 +4,12 @@
             class="control-label"
             v-text="label"
         />
+        <i
+            v-if="helpText"
+            v-tooltip
+            :title="helpText"
+            class="attribute-help-text fa fa-question-circle"
+        ></i>
         <div class="radio-inline">
             <label>
                 <input
@@ -33,8 +39,9 @@
     export default {
         name: 'YesNoRadioField',
         props: {
-            label: { required: true, type: String },
-            value: { type: Boolean, required: true }
+            value: { type: Boolean, required: true },
+            label: { type: String, required: true },
+            helpText: { type: String, requird: false, default: "" },
         }
     }
 </script>

--- a/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
@@ -40,12 +40,11 @@
                             </div>
                             <div class="form-group">
                                 <label>Help Text</label>
-                                <input
+                                <textarea
                                     v-model="definition.helpText"
-                                    type="text"
                                     class="form-control"
                                     placeholder="Enter help text"
-                                >
+                                ></textarea>
                             </div>
                             <OptionListStatic
                                 v-model="definition.type"

--- a/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
@@ -38,6 +38,15 @@
                                     placeholder="Enter attribute name"
                                 >
                             </div>
+                            <div class="form-group">
+                                <label>Help Text</label>
+                                <input
+                                    v-model="definition.helpText"
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="Enter help text"
+                                >
+                            </div>
                             <OptionListStatic
                                 v-model="definition.type"
                                 label="Attribute Type"

--- a/assets/sass/_happybottoms.scss
+++ b/assets/sass/_happybottoms.scss
@@ -61,6 +61,11 @@
   color: #fff !important;
 }
 
+.attribute-help-text {
+  color: #aaa;
+  padding-left: .4em;
+}
+
 .page-break-after {
   page-break-after: always;
 }

--- a/src/Entity/EAV/Definition.php
+++ b/src/Entity/EAV/Definition.php
@@ -79,6 +79,13 @@ abstract class Definition extends CoreEntity
     /**
      * @var string
      *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $helpText;
+
+    /**
+     * @var string
+     *
      * @ORM\Column(type="string", length=100)
      */
     private $displayInterface;
@@ -223,6 +230,24 @@ abstract class Definition extends CoreEntity
     public function getType() : string
     {
         return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHelpText()
+    {
+        return $this->helpText;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHelpText($helpText)
+    {
+        $this->helpText = $helpText;
+
+        return $this;
     }
 
     public function getDisplayInterface(): string

--- a/src/Transformers/AttributeDefinitionTransformer.php
+++ b/src/Transformers/AttributeDefinitionTransformer.php
@@ -18,6 +18,7 @@ class AttributeDefinitionTransformer extends TransformerAbstract
             'name' => $definition->getName(),
             'label' => $definition->getLabel(),
             'type' => $definition->getType(),
+            'helpText' => $definition->getHelpText(),
             'displayInterface' => $definition->getDisplayInterface(),
             'description' => $definition->getDescription(),
             'required' => $definition->getRequired(),

--- a/src/Transformers/AttributeTransformer.php
+++ b/src/Transformers/AttributeTransformer.php
@@ -23,6 +23,7 @@ class AttributeTransformer extends TransformerAbstract
             'name' => $attribute->getDefinition()->getName(),
             'label' => $attribute->getDefinition()->getLabel(),
             'type' => $attribute->getDefinition()->getType(),
+            'helpText' => $attribute->getDefinition()->getHelpText(),
             'displayInterface' => $attribute->getDefinition()->getDisplayInterface(),
             'value' => $attribute->getJsonValue(),
             'orderIndex' => $attribute->getDefinition()->getOrderIndex(),


### PR DESCRIPTION
This update should give you the ability to add custom help text (of max-length 255) to any Client or Partner Attribute. The uri to try that out is: /#/admin/attributes/client ...

Once you have added help text to any attributes, you should then see a little icon with a tooltip next to its corresponding label on the detail page found under Client Management or Partner Management. Those uris are: /#/clients + /#/partners

Of course we can display these hints however you wish. 2 screenshots are attached to see v1.

<img width="397" alt="image" src="https://user-images.githubusercontent.com/6778708/88883820-d68fd100-d1fa-11ea-813f-3a738ba57085.png">

<img width="278" alt="image" src="https://user-images.githubusercontent.com/6778708/88883884-fb844400-d1fa-11ea-9d0c-0f173ef7f8c6.png">

Let me know what you think!