### PR TITLE
152 cannot create client

### DIFF
--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -98,6 +98,9 @@ class ClientController extends BaseController
 
         if ($params['partner']['id']) {
             $newPartner = $this->getEm()->find(Partner::class, $params['partner']['id']);
+            if (!$newPartner) {
+                throw new \Exception('Invalid Partner ID provided');
+            }
             $client->setPartner($newPartner);
         }
 
@@ -130,6 +133,9 @@ class ClientController extends BaseController
 
         if (isset($params['partner']['id'])) {
             $newPartner = $this->getEm()->find(Partner::class, $params['partner']['id']);
+            if (!$newPartner) {
+                throw new \Exception('Invalid Partner ID provided');
+            }
             $client->setPartner($newPartner);
         }
 

--- a/src/DataFixtures/PartnerFixtures.php
+++ b/src/DataFixtures/PartnerFixtures.php
@@ -45,6 +45,7 @@ class PartnerFixtures extends BaseFixture
         for ($i = 0; $i < 50; $i++) {
             $partner = new Partner($this->faker->company . ' Partner', $this->workflowRegistry);
             $partner->setPartnerType(Partner::TYPE_AGENCY);
+            $partner->setStatus($this->randValue(Partner::STATUSES));
             $partner->setDistributionMethod($this->randValue($distributionMethods));
             $partner->setFulfillmentPeriod($this->randValue($periods));
             $partner->addContact($this->createContact(StorageLocationContact::class));
@@ -53,9 +54,11 @@ class PartnerFixtures extends BaseFixture
             $manager->persist($partner);
         }
 
-        for ($i = 0; $i < 4; $i++) {
+        $numStatuses = count(Partner::STATUSES);
+        for ($i = 0; $i < ($numStatuses * 2); $i++) {
             $hospital = new Partner($this->faker->company . ' Hospital', $this->workflowRegistry);
             $hospital->setPartnerType(Partner::TYPE_HOSPITAL);
+            $hospital->setStatus(Partner::STATUSES[$i % $numStatuses]);
             $hospital->setDistributionMethod($this->randValue($distributionMethods));
             $hospital->setFulfillmentPeriod($this->randValue($periods));
             $hospital->addContact($this->createContact(StorageLocationContact::class));


### PR DESCRIPTION
This started out as a way to resolve #152, but the effort was duplicated by #153 . This evolved from there.

This fixes fixtures so active clients load with populated partners and new clients can be created with an active partner.

Resolves #152 