### PR TITLE
103 add workflow permissions for clients

### DIFF
--- a/src/EventSubscriber/Workflow/ClientSubscriber.php
+++ b/src/EventSubscriber/Workflow/ClientSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\EventSubscriber\Workflow;
+
+use App\Entity\Client;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Workflow\Event\GuardEvent;
+
+class ClientSubscriber implements EventSubscriberInterface
+{
+    /** @var AuthorizationCheckerInterface */
+    protected $checker;
+
+    public function __construct(AuthorizationCheckerInterface $checker)
+    {
+        $this->checker = $checker;
+    }
+
+    public function onTransition(GuardEvent $event): void
+    {
+        if (!$this->checker->isGranted('IS_AUTHENTICATED_FULLY')) {
+            $event->setBlocked(true);
+        }
+    }
+
+    public function onTransitionActivate(GuardEvent $event): void
+    {
+        if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN) &&
+            !$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            $event->setBlocked(true);
+        }
+    }
+
+    public function onTransitionDeactivate(GuardEvent $event): void
+    {
+        if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN) &&
+            !$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            $event->setBlocked(true);
+        }
+    }
+
+    public function onTransitionExpire(GuardEvent $event): void
+    {
+        if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            $event->setBlocked(true);
+        }
+    }
+
+    public function onTransitionDuplicateInactive(GuardEvent $event): void
+    {
+        if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            $event->setBlocked(true);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            'workflow.client_management.guard' => 'onTransition',
+            'workflow.client_management.guard.ACTIVATE' => 'onTransitionActivate',
+            'workflow.client_management.guard.DEACTIVATE' => 'onTransitionDeactivate',
+            'workflow.client_management.guard.EXPIRE' => 'onTransitionExpire',
+            'workflow.client_management.guard.DUPLICATE' => 'onTransitionDuplicateInactive',
+        ];
+    }
+}

--- a/src/EventSubscriber/Workflow/ClientSubscriber.php
+++ b/src/EventSubscriber/Workflow/ClientSubscriber.php
@@ -26,17 +26,31 @@ class ClientSubscriber implements EventSubscriberInterface
 
     public function onTransitionActivate(GuardEvent $event): void
     {
-        if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN) &&
-            !$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
-            $event->setBlocked(true);
+        if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            ['status' => $status] = $event->getSubject();
+
+            if ($status === Client::STATUS_LIMIT_REACHED || $status === Client::STATUS_DUPLICATE_INACTIVE) {
+                $event->setBlocked(true);
+            }
+
+            if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN)) {
+                $event->setBlocked(true);
+            }
         }
     }
 
     public function onTransitionDeactivate(GuardEvent $event): void
     {
-        if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN) &&
-            !$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
-            $event->setBlocked(true);
+        if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
+            ['status' => $status] = $event->getSubject();
+
+            if ($status === Client::STATUS_LIMIT_REACHED || $status === Client::STATUS_DUPLICATE_INACTIVE) {
+                $event->setBlocked(true);
+            }
+
+            if (!$this->checker->isGranted(Client::ROLE_MANAGE_OWN)) {
+                $event->setBlocked(true);
+            }
         }
     }
 

--- a/src/Security/ClientVoter.php
+++ b/src/Security/ClientVoter.php
@@ -45,7 +45,7 @@ class ClientVoter extends Voter
         }
     }
 
-    private function canView(Client $client, User $user)
+    private function canView(Client $client, User $user): bool
     {
         if ($this->canEdit($client, $user)) {
             return true;
@@ -58,7 +58,7 @@ class ClientVoter extends Voter
         return false;
     }
 
-    private function canEdit(Client $client, User $user)
+    private function canEdit(Client $client, User $user): bool
     {
         if ($user->isAdmin()) {
             return true;
@@ -69,14 +69,11 @@ class ClientVoter extends Voter
         }
 
         $activePartner = $user->getActivePartner();
+        $clientPartner = $client->getPartner();
 
-        if ($user->hasRole(Client::ROLE_MANAGE_OWN)
-            && $activePartner
-            && $client->getPartner()->getId() === $activePartner->getId()
-        ) {
-            return true;
-        }
-
-        return false;
+        return $activePartner
+            && $clientPartner
+            && $user->hasRole(Client::ROLE_MANAGE_OWN)
+            && $clientPartner->getId() === $activePartner->getId();
     }
 }

--- a/src/Security/ClientVoter.php
+++ b/src/Security/ClientVoter.php
@@ -41,7 +41,7 @@ class ClientVoter extends Voter
             case self::EDIT:
                 return $this->canEdit($client, $user);
             default:
-                throw new \LogicException('This code should not be reached!');
+                throw new \LogicException('Unknown Voter attribute');
         }
     }
 


### PR DESCRIPTION
Fixes 103 by adding a client subscriber that acts a client workflow guards. The guards are using the Client Voter.

The change looks simple enough, but the difficulty was in learning how to do this simple change in the first place :)