### PR TITLE
Start Scanning Against PSR-12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for showing interest in helping make this project better for all!
 
 For PHP:
 
-* Code Style: [PSR-12](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)
-* Name Spaces: [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
+* Code Style: [PSR-12](https://www.php-fig.org/psr/psr-12/)
+* Name Spaces: [PSR-4](https://www.php-fig.org/psr/psr-4/)
 * Static Analysis: [PHPStan](https://github.com/phpstan/phpstan)
 
 For JavaScript:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for showing interest in helping make this project better for all!
 
 For PHP:
 
-* Code Style: [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+* Code Style: [PSR-12](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md)
 * Name Spaces: [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
 * Static Analysis: [PHPStan](https://github.com/phpstan/phpstan)
 

--- a/composer.lock
+++ b/composer.lock
@@ -98,6 +98,61 @@
             "time": "2020-04-15T15:59:35+00:00"
         },
         {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "reference": "98df7f1b293c0550bd5b1ce6b60b59bdda23aa47",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.2 - 1.8.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2020-04-23T11:49:37+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.10.3",
             "source": {
@@ -2022,57 +2077,6 @@
                 "crossdomain"
             ],
             "time": "2019-06-17T08:53:14+00:00"
-        },
-        {
-            "name": "ocramius/package-versions",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
-                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.3.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.8.6",
-                "doctrine/coding-standard": "^6.0.0",
-                "ext-zip": "*",
-                "infection/infection": "^0.13.4",
-                "phpunit/phpunit": "^8.2.5",
-                "vimeo/psalm": "^3.4.9"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-07-17T15:49:50+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -7155,16 +7159,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -7202,7 +7206,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <file>src/</file>
 

--- a/src/Controller/AdjustmentOrderController.php
+++ b/src/Controller/AdjustmentOrderController.php
@@ -5,8 +5,8 @@ namespace App\Controller;
 use App\Entity\Orders\AdjustmentOrder;
 use App\Entity\Orders\AdjustmentOrderLineItem;
 use App\Entity\StorageLocation;
-use App\Transformers\AdjustmentOrderTransformer;
 use App\Security\AdjustmentOrderVoter;
+use App\Transformers\AdjustmentOrderTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -99,6 +99,6 @@ class AdjustmentOrderController extends OrderController
 
     protected function getDefaultTransformer()
     {
-        return new AdjustmentOrderTransformer;
+        return new AdjustmentOrderTransformer();
     }
 }

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -112,7 +112,7 @@ abstract class BaseController extends AbstractController
      * @param Request $request
      * @return array
      */
-    protected function getParams(Request $request) : array
+    protected function getParams(Request $request): array
     {
         // TODO: This needs to redone to check the type of request and only give back the right params for that method
         $params = $request->request->all();

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -7,8 +7,6 @@ use App\Transformers\GroupTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -157,6 +155,6 @@ class GroupController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new GroupTransformer;
+        return new GroupTransformer();
     }
 }

--- a/src/Controller/ListOptionController.php
+++ b/src/Controller/ListOptionController.php
@@ -117,6 +117,6 @@ abstract class ListOptionController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new ListOptionTransformer;
+        return new ListOptionTransformer();
     }
 }

--- a/src/Controller/MerchandiseOrderController.php
+++ b/src/Controller/MerchandiseOrderController.php
@@ -97,6 +97,6 @@ class MerchandiseOrderController extends OrderController
 
     protected function getDefaultTransformer()
     {
-        return new MerchandiseOrderTransformer;
+        return new MerchandiseOrderTransformer();
     }
 }

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -246,7 +246,7 @@ class OrderController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new OrderTransformer;
+        return new OrderTransformer();
     }
 
     protected function processLineItems(Order $order, $lineItemsArray)

--- a/src/Controller/PartnerController.php
+++ b/src/Controller/PartnerController.php
@@ -6,9 +6,9 @@ use App\Entity\Partner;
 use App\Entity\PartnerDistributionMethod;
 use App\Entity\PartnerFulfillmentPeriod;
 use App\Entity\PartnerProfile;
+use App\Security\PartnerVoter;
 use App\Transformers\ClientTransformer;
 use App\Transformers\PartnerTransformer;
-use App\Security\PartnerVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -165,7 +165,7 @@ class PartnerController extends BaseController
     {
         $partner = $this->getPartnerById($id);
 
-        return $this->serialize($request, $partner->getClients()->getValues(), new ClientTransformer);
+        return $this->serialize($request, $partner->getClients()->getValues(), new ClientTransformer());
     }
 
     /**
@@ -197,7 +197,7 @@ class PartnerController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new PartnerTransformer;
+        return new PartnerTransformer();
     }
 
     protected function getPartnerById($id): Partner

--- a/src/Controller/PartnerDistributionController.php
+++ b/src/Controller/PartnerDistributionController.php
@@ -6,7 +6,6 @@ use App\Entity\Client;
 use App\Entity\LineItem;
 use App\Entity\Orders\BulkDistribution;
 use App\Entity\Orders\BulkDistributionLineItem;
-use App\Entity\Orders\PartnerOrder;
 use App\Entity\Partner;
 use App\Entity\User;
 use App\Transformers\BulkDistributionLineItemTransformer;
@@ -138,7 +137,7 @@ class PartnerDistributionController extends OrderController
             return $line;
         }, $clients);
 
-        return $this->serialize($request, $lineItems, new BulkDistributionLineItemTransformer);
+        return $this->serialize($request, $lineItems, new BulkDistributionLineItemTransformer());
     }
 
     protected function buildFilterParams(Request $request)

--- a/src/Controller/PartnerDistributionMethodController.php
+++ b/src/Controller/PartnerDistributionMethodController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Entity\PartnerDistributionMethod;

--- a/src/Controller/PartnerFulfillmentPeriodController.php
+++ b/src/Controller/PartnerFulfillmentPeriodController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Entity\PartnerFulfillmentPeriod;

--- a/src/Controller/ProductCategoryController.php
+++ b/src/Controller/ProductCategoryController.php
@@ -1,9 +1,8 @@
 <?php
+
 namespace App\Controller;
 
-use App\Entity\PartnerDistributionMethod;
 use App\Entity\ProductCategory;
-use App\Transformers\ListOptionTransformer;
 use App\Transformers\ProductCategoryTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\Routing\Annotation\Route;
@@ -23,7 +22,7 @@ class ProductCategoryController extends ListOptionController
 
     protected function getListOptionEntityInstance()
     {
-        return new ProductCategory;
+        return new ProductCategory();
     }
 
     protected function getDefaultTransformer()

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -211,6 +211,6 @@ class ProductController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new ProductTransformer;
+        return new ProductTransformer();
     }
 }

--- a/src/Controller/StorageLocationController.php
+++ b/src/Controller/StorageLocationController.php
@@ -152,6 +152,6 @@ class StorageLocationController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new StorageLocationTransformer;
+        return new StorageLocationTransformer();
     }
 }

--- a/src/Controller/SupplierController.php
+++ b/src/Controller/SupplierController.php
@@ -3,15 +3,15 @@
 namespace App\Controller;
 
 use App\Entity\Supplier;
+use App\Security\SupplierVoter;
 use App\Transformers\SupplierOptionTransformer;
 use App\Transformers\SupplierTransformer;
-use App\Security\SupplierVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -264,6 +264,6 @@ class SupplierController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new SupplierTransformer;
+        return new SupplierTransformer();
     }
 }

--- a/src/Controller/SupplyOrderController.php
+++ b/src/Controller/SupplyOrderController.php
@@ -7,8 +7,8 @@ use App\Entity\Orders\SupplyOrderLineItem;
 use App\Entity\Supplier;
 use App\Entity\SupplierAddress;
 use App\Entity\Warehouse;
-use App\Transformers\SupplyOrderTransformer;
 use App\Security\SupplyOrderVoter;
+use App\Transformers\SupplyOrderTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -122,6 +122,6 @@ class SupplyOrderController extends OrderController
 
     protected function getDefaultTransformer()
     {
-        return new SupplyOrderTransformer;
+        return new SupplyOrderTransformer();
     }
 }

--- a/src/Controller/SystemController.php
+++ b/src/Controller/SystemController.php
@@ -86,7 +86,7 @@ class SystemController extends BaseController
      */
     public function getLoggedInUser(Request $request)
     {
-        return $this->serialize($request, $this->getUser(), new UserTransformer);
+        return $this->serialize($request, $this->getUser(), new UserTransformer());
     }
 
     private function getSettings()

--- a/src/Controller/TransferOrdersController.php
+++ b/src/Controller/TransferOrdersController.php
@@ -5,8 +5,8 @@ namespace App\Controller;
 use App\Entity\Orders\TransferOrder;
 use App\Entity\Orders\TransferOrderLineItem;
 use App\Entity\StorageLocation;
-use App\Transformers\TransferOrderTransformer;
 use App\Security\TransferOrderVoter;
+use App\Transformers\TransferOrderTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -114,6 +114,6 @@ class TransferOrdersController extends OrderController
 
     protected function getDefaultTransformer()
     {
-        return new TransferOrderTransformer;
+        return new TransferOrderTransformer();
     }
 }

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -4,11 +4,11 @@ namespace App\Controller;
 
 use App\Entity\Group;
 use App\Entity\Partner;
-use App\Entity\User;
 use App\Entity\PartnerUser;
+use App\Entity\User;
 use App\Entity\ValueObjects\Name;
-use App\Transformers\UserTransformer;
 use App\Security\UserVoter;
+use App\Transformers\UserTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +33,7 @@ class UserController extends BaseController
      * @IsGranted({"ROLE_USER_VIEW"})
      *
      */
-    public function index(Request $request) : JsonResponse
+    public function index(Request $request): JsonResponse
     {
         $users = $this->getRepository()->findAll();
 
@@ -51,7 +51,7 @@ class UserController extends BaseController
      * })
      *
      */
-    public function partnerIndex(Request $request, string $partnerId) : JsonResponse
+    public function partnerIndex(Request $request, string $partnerId): JsonResponse
     {
         $partner = $this->getRepository(Partner::class)->find($partnerId);
         $users = $this->getRepository()->findByPartner($partner);
@@ -83,7 +83,7 @@ class UserController extends BaseController
      * @IsGranted({"ROLE_USER_EDIT"})
      *
      */
-    public function store(Request $request) : JsonResponse
+    public function store(Request $request): JsonResponse
     {
         $params = $this->getParams($request);
         $user = new User($params["email"]);
@@ -127,7 +127,7 @@ class UserController extends BaseController
      * @IsGranted({"ROLE_USER_EDIT"})
      *
      */
-    public function update(Request $request, string $id) : JsonResponse
+    public function update(Request $request, string $id): JsonResponse
     {
         $params = $this->getParams($request);
         /** @var User $user */
@@ -212,7 +212,7 @@ class UserController extends BaseController
 
     protected function getDefaultTransformer()
     {
-        return new UserTransformer;
+        return new UserTransformer();
     }
 
     protected function getUserById($id): User

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -28,7 +28,7 @@ abstract class BaseFixture extends Fixture
         $this->loadData($manager);
     }
 
-    protected function createAddress($class) : Address
+    protected function createAddress($class): Address
     {
         /** @var Address $address */
         $address = new $class();
@@ -41,7 +41,7 @@ abstract class BaseFixture extends Fixture
         return $address;
     }
 
-    protected function createContact($class) : Contact
+    protected function createContact($class): Contact
     {
         /** @var Contact $contact */
         $contact = new $class();

--- a/src/DataFixtures/BulkDistributionFixtures.php
+++ b/src/DataFixtures/BulkDistributionFixtures.php
@@ -4,10 +4,8 @@ namespace App\DataFixtures;
 
 use App\Entity\Orders\BulkDistribution;
 use App\Entity\Orders\BulkDistributionLineItem;
-use App\Entity\Orders\PartnerOrder;
-use App\Entity\Orders\PartnerOrderLineItem;
-use App\Entity\Product;
 use App\Entity\Partner;
+use App\Entity\Product;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Moment\Moment;
@@ -35,7 +33,7 @@ class BulkDistributionFixtures extends BaseFixture implements DependentFixtureIn
 
         foreach ($partners as $partner) {
             $clients = $partner->getClients();
-            for ($i=0; $i < $ordersPerPartner; $i++) {
+            for ($i = 0; $i < $ordersPerPartner; $i++) {
                 $order = new BulkDistribution($partner);
 
                 $order->setStatus($this->faker->randomElement([

--- a/src/DataFixtures/ClientFixtures.php
+++ b/src/DataFixtures/ClientFixtures.php
@@ -75,7 +75,8 @@ class ClientFixtures extends BaseFixture implements DependentFixtureInterface
         for ($i = 0; $i < $clientsToCreate; $i++) {
             $status = $this->getClientStatus();
             $partner = null;
-            if ($status === Client::STATUS_CREATION
+            if (
+                $status === Client::STATUS_CREATION
                 || $status === Client::STATUS_ACTIVE
                 || $status === Client::STATUS_LIMIT_REACHED
             ) {

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -13,7 +13,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 abstract class Address extends CoreEntity
 {
-    const DEFAULT_VALIDATIONS = [
+    public const DEFAULT_VALIDATIONS = [
         'street1' => 'required',
         'city' => 'required',
         'state' => 'required',

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -21,6 +21,9 @@ use Symfony\Component\Workflow\Registry;
  */
 class Client extends CoreEntity
 {
+    use Uuidable;
+    use AttributedEntityTrait;
+
     public const STATUS_CREATION = 'CREATION';
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_INACTIVE = 'INACTIVE';
@@ -35,9 +38,6 @@ class Client extends CoreEntity
     public const ROLE_VIEW_ALL = "ROLE_CLIENT_VIEW_ALL";
     public const ROLE_EDIT_ALL = "ROLE_CLIENT_EDIT_ALL";
     public const ROLE_MANAGE_OWN = "ROLE_CLIENT_MANAGE_OWN";
-
-    use Uuidable;
-    use AttributedEntityTrait;
 
     /**
      * The name value object which holds the

--- a/src/Entity/CoreEntity.php
+++ b/src/Entity/CoreEntity.php
@@ -20,7 +20,8 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
  */
 abstract class CoreEntity
 {
-    use TimestampableEntity, SoftDeleteableEntity;
+    use TimestampableEntity;
+    use SoftDeleteableEntity;
 
     /**
      * Every entity will have an id
@@ -141,7 +142,8 @@ abstract class CoreEntity
         }
 
         return array_reduce($annotations, function ($carry, $annotation) {
-            if ($annotation instanceof OneToMany
+            if (
+                $annotation instanceof OneToMany
             ) {
                 return true;
             }
@@ -174,7 +176,8 @@ abstract class CoreEntity
         }
 
         return array_reduce($annotations, function ($carry, $annotation) {
-            if ($annotation instanceof ManyToMany ||
+            if (
+                $annotation instanceof ManyToMany ||
                 $annotation instanceof ManyToOne
             ) {
                 return true;

--- a/src/Entity/CoreEntity.php
+++ b/src/Entity/CoreEntity.php
@@ -142,9 +142,7 @@ abstract class CoreEntity
         }
 
         return array_reduce($annotations, function ($carry, $annotation) {
-            if (
-                $annotation instanceof OneToMany
-            ) {
+            if ($annotation instanceof OneToMany) {
                 return true;
             }
 
@@ -176,10 +174,7 @@ abstract class CoreEntity
         }
 
         return array_reduce($annotations, function ($carry, $annotation) {
-            if (
-                $annotation instanceof ManyToMany ||
-                $annotation instanceof ManyToOne
-            ) {
+            if ($annotation instanceof ManyToMany || $annotation instanceof ManyToOne) {
                 return true;
             }
 

--- a/src/Entity/EAV/Attribute.php
+++ b/src/Entity/EAV/Attribute.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity\EAV;
 
-use App\Entity\CoreEntity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -71,12 +70,12 @@ abstract class Attribute
 
     abstract public function getValue();
 
-    abstract public function getDisplayInterfaces() : array;
+    abstract public function getDisplayInterfaces(): array;
 
     /**
      * By default this will just get the first interface in the list. Override as necessary.
      */
-    public function getDefaultDisplayInterface() : string
+    public function getDefaultDisplayInterface(): string
     {
         $interfaces = $this->getDisplayInterfaces();
         return reset($interfaces);
@@ -85,7 +84,7 @@ abstract class Attribute
     /**
      * Whether this type supports list options (dropdown, radio, checkboxes, etc)
      */
-    public function hasOptions() : bool
+    public function hasOptions(): bool
     {
         return false;
     }

--- a/src/Entity/EAV/Attribute.php
+++ b/src/Entity/EAV/Attribute.php
@@ -13,20 +13,20 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class Attribute
 {
-    const UI_TEXT = "TEXT";
-    const UI_NUMBER = "NUMBER";
-    const UI_TEXTAREA = "TEXTAREA";
-    const UI_DATETIME = "DATETIME";
-    const UI_SELECT_SINGLE = "SELECT_SINGLE";
-    const UI_SELECT_MULTI = "SELECT_MULTI";
-    const UI_FILE_UPLOAD = "FILE_UPLOAD";
-    const UI_RADIO = "RADIO";
-    const UI_CHECKBOX_GROUP = "CHECKBOX_GROUP";
-    const UI_TOGGLE = "TOGGLE";
-    const UI_YES_NO_RADIO = "YES_NO_RADIO";
-    const UI_ADDRESS = "ADDRESS";
-    const UI_URL = "URL";
-    const UI_ZIPCODE = "ZIPCODE";
+    public const UI_TEXT = "TEXT";
+    public const UI_NUMBER = "NUMBER";
+    public const UI_TEXTAREA = "TEXTAREA";
+    public const UI_DATETIME = "DATETIME";
+    public const UI_SELECT_SINGLE = "SELECT_SINGLE";
+    public const UI_SELECT_MULTI = "SELECT_MULTI";
+    public const UI_FILE_UPLOAD = "FILE_UPLOAD";
+    public const UI_RADIO = "RADIO";
+    public const UI_CHECKBOX_GROUP = "CHECKBOX_GROUP";
+    public const UI_TOGGLE = "TOGGLE";
+    public const UI_YES_NO_RADIO = "YES_NO_RADIO";
+    public const UI_ADDRESS = "ADDRESS";
+    public const UI_URL = "URL";
+    public const UI_ZIPCODE = "ZIPCODE";
 
     /**
      * @var int

--- a/src/Entity/EAV/Definition.php
+++ b/src/Entity/EAV/Definition.php
@@ -26,17 +26,17 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 abstract class Definition extends CoreEntity
 {
-    const TYPE_STRING = "STRING";
-    const TYPE_INTEGER = "INTEGER";
-    const TYPE_FLOAT = "FLOAT";
-    const TYPE_DATETIME = "DATETIME";
-    const TYPE_OPTION_LIST = "OPTION_LIST";
-    const TYPE_TEXT = "TEXT";
-    const TYPE_FILE = "FILE";
-    const TYPE_ADDRESS = "ADDRESS";
-    const TYPE_URL = "URL";
-    const TYPE_BOOLEAN = "BOOLEAN";
-    const TYPE_ZIPCODE = "ZIPCODE";
+    public const TYPE_STRING = "STRING";
+    public const TYPE_INTEGER = "INTEGER";
+    public const TYPE_FLOAT = "FLOAT";
+    public const TYPE_DATETIME = "DATETIME";
+    public const TYPE_OPTION_LIST = "OPTION_LIST";
+    public const TYPE_TEXT = "TEXT";
+    public const TYPE_FILE = "FILE";
+    public const TYPE_ADDRESS = "ADDRESS";
+    public const TYPE_URL = "URL";
+    public const TYPE_BOOLEAN = "BOOLEAN";
+    public const TYPE_ZIPCODE = "ZIPCODE";
 
     /**
      * @var int

--- a/src/Entity/EAV/Definition.php
+++ b/src/Entity/EAV/Definition.php
@@ -228,7 +228,7 @@ abstract class Definition extends CoreEntity
         return $this;
     }
 
-    public function getType() : string
+    public function getType(): string
     {
         return $this->type;
     }
@@ -378,7 +378,7 @@ abstract class Definition extends CoreEntity
         return $this->attributes;
     }
 
-    public static function getAttributeTypes() : array
+    public static function getAttributeTypes(): array
     {
         return [
             self::TYPE_DATETIME,
@@ -394,7 +394,7 @@ abstract class Definition extends CoreEntity
         ];
     }
 
-    public static function createNewAttributeFromType(string $type) : Attribute
+    public static function createNewAttributeFromType(string $type): Attribute
     {
         $attribute = new StringAttribute();
 
@@ -428,7 +428,7 @@ abstract class Definition extends CoreEntity
         return $attribute;
     }
 
-    public function createAttribute($value = null) : Attribute
+    public function createAttribute($value = null): Attribute
     {
         $attribute = null;
 

--- a/src/Entity/EAV/Type/BooleanAttribute.php
+++ b/src/Entity/EAV/Type/BooleanAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/EAV/Type/DatetimeAttribute.php
+++ b/src/Entity/EAV/Type/DatetimeAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/EAV/Type/FloatAttribute.php
+++ b/src/Entity/EAV/Type/FloatAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;
@@ -47,7 +46,7 @@ class FloatAttribute extends Attribute
 
     public function fixtureData()
     {
-        return rand()/mt_getrandmax() * 10;
+        return rand() / mt_getrandmax() * 10;
     }
 
     public function getDisplayInterfaces(): array

--- a/src/Entity/EAV/Type/IntegerAttribute.php
+++ b/src/Entity/EAV/Type/IntegerAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/EAV/Type/OptionListAttribute.php
+++ b/src/Entity/EAV/Type/OptionListAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/EAV/Type/StringAttribute.php
+++ b/src/Entity/EAV/Type/StringAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/EAV/Type/TextAttribute.php
+++ b/src/Entity/EAV/Type/TextAttribute.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity\EAV\Type;
 
 use App\Entity\EAV\Attribute;

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -112,7 +112,7 @@ class Group extends CoreEntity
         $this->name = $name;
     }
 
-    public function getRoles() : array
+    public function getRoles(): array
     {
         return $this->roles;
     }

--- a/src/Entity/Group.php
+++ b/src/Entity/Group.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Group extends CoreEntity
 {
-    const AVAILABLE_ROLES = [
+    public const AVAILABLE_ROLES = [
         User::ROLE_ADMIN,
 
         Order::ROLE_MANAGE_OWN,

--- a/src/Entity/ListOption.php
+++ b/src/Entity/ListOption.php
@@ -16,8 +16,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 abstract class ListOption extends CoreEntity
 {
-    const STATUS_ACTIVE = "ACTIVE";
-    const STATUS_INACTIVE = "INACTIVE";
+    public const STATUS_ACTIVE = "ACTIVE";
+    public const STATUS_INACTIVE = "INACTIVE";
 
     /**
      * @var int

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -21,11 +21,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 abstract class Order extends CoreEntity
 {
-    const STATUS_COMPLETED = "COMPLETED";
+    public const STATUS_COMPLETED = "COMPLETED";
 
-    const ROLE_VIEW_ALL = "ROLE_ORDER_VIEW_ALL";
-    const ROLE_EDIT_ALL = "ROLE_ORDER_EDIT_ALL";
-    const ROLE_MANAGE_OWN = "ROLE_ORDER_MANAGE_OWN";
+    public const ROLE_VIEW_ALL = "ROLE_ORDER_VIEW_ALL";
+    public const ROLE_EDIT_ALL = "ROLE_ORDER_EDIT_ALL";
+    public const ROLE_MANAGE_OWN = "ROLE_ORDER_MANAGE_OWN";
 
     /**
      * @var int

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -70,9 +70,9 @@ abstract class Order extends CoreEntity
      *
      * @return string
      */
-    abstract public function getOrderTypeName() : string;
+    abstract public function getOrderTypeName(): string;
 
-    abstract public function getOrderSequencePrefix() : string;
+    abstract public function getOrderSequencePrefix(): string;
 
     /**
      * @return int

--- a/src/Entity/Orders/AdjustmentOrder.php
+++ b/src/Entity/Orders/AdjustmentOrder.php
@@ -13,8 +13,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class AdjustmentOrder extends Order
 {
-    const ROLE_VIEW = "ROLE_ADJUSTMENT_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_ADJUSTMENT_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_ADJUSTMENT_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_ADJUSTMENT_ORDER_EDIT";
 
     /**
      * @var StorageLocation $storageLocation

--- a/src/Entity/Orders/AdjustmentOrder.php
+++ b/src/Entity/Orders/AdjustmentOrder.php
@@ -39,7 +39,7 @@ class AdjustmentOrder extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Stock Change";
     }

--- a/src/Entity/Orders/BulkDistribution.php
+++ b/src/Entity/Orders/BulkDistribution.php
@@ -55,7 +55,7 @@ class BulkDistribution extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Partner Distribution";
     }

--- a/src/Entity/Orders/BulkDistribution.php
+++ b/src/Entity/Orders/BulkDistribution.php
@@ -15,10 +15,10 @@ use Moment\Moment;
  */
 class BulkDistribution extends Order
 {
-    const STATUS_PENDING = "PENDING";
+    public const STATUS_PENDING = "PENDING";
 
-    const ROLE_VIEW = "ROLE_DISTRIBUTION_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_DISTRIBUTION_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_DISTRIBUTION_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_DISTRIBUTION_ORDER_EDIT";
 
     /**
      * @var Partner $partner

--- a/src/Entity/Orders/MerchandiseOrder.php
+++ b/src/Entity/Orders/MerchandiseOrder.php
@@ -13,8 +13,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class MerchandiseOrder extends Order
 {
-    const ROLE_VIEW = "ROLE_MERCHANDISE_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_MERCHANDISE_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_MERCHANDISE_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_MERCHANDISE_ORDER_EDIT";
 
     /**
      * @var Warehouse $warehouse

--- a/src/Entity/Orders/MerchandiseOrder.php
+++ b/src/Entity/Orders/MerchandiseOrder.php
@@ -34,7 +34,7 @@ class MerchandiseOrder extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Merchandise Order";
     }

--- a/src/Entity/Orders/PartnerOrder.php
+++ b/src/Entity/Orders/PartnerOrder.php
@@ -68,7 +68,7 @@ class PartnerOrder extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Partner Order";
     }

--- a/src/Entity/Orders/PartnerOrder.php
+++ b/src/Entity/Orders/PartnerOrder.php
@@ -17,12 +17,12 @@ use Moment\Moment;
  */
 class PartnerOrder extends Order
 {
-    const STATUS_IN_PROCESS = "IN_PROCESS";
-    const STATUS_PENDING = "PENDING";
-    const STATUS_SHIPPED = "SHIPPED";
+    public const STATUS_IN_PROCESS = "IN_PROCESS";
+    public const STATUS_PENDING = "PENDING";
+    public const STATUS_SHIPPED = "SHIPPED";
 
-    const ROLE_VIEW = "ROLE_PARTNER_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_PARTNER_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_PARTNER_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_PARTNER_ORDER_EDIT";
 
     /**
      * @var Partner $partner

--- a/src/Entity/Orders/SupplyOrder.php
+++ b/src/Entity/Orders/SupplyOrder.php
@@ -68,7 +68,7 @@ class SupplyOrder extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Supply Order";
     }

--- a/src/Entity/Orders/SupplyOrder.php
+++ b/src/Entity/Orders/SupplyOrder.php
@@ -18,8 +18,8 @@ use Gedmo\Mapping\Annotation as Gedmo;
  */
 class SupplyOrder extends Order
 {
-    const STATUS_ORDERED = "ORDERED";
-    const STATUS_RECEIVED = "RECEIVED";
+    public const STATUS_ORDERED = "ORDERED";
+    public const STATUS_RECEIVED = "RECEIVED";
 
     public const ROLE_VIEW = "ROLE_SUPPLY_ORDER_VIEW";
     public const ROLE_EDIT = "ROLE_SUPPLY_ORDER_EDIT";

--- a/src/Entity/Orders/TransferOrder.php
+++ b/src/Entity/Orders/TransferOrder.php
@@ -16,8 +16,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class TransferOrder extends Order
 {
-    const ROLE_VIEW = "ROLE_TRANSFER_ORDER_VIEW";
-    const ROLE_EDIT = "ROLE_TRANSFER_ORDER_EDIT";
+    public const ROLE_VIEW = "ROLE_TRANSFER_ORDER_VIEW";
+    public const ROLE_EDIT = "ROLE_TRANSFER_ORDER_EDIT";
 
     /**
      * @var StorageLocation $sourceLocation

--- a/src/Entity/Orders/TransferOrder.php
+++ b/src/Entity/Orders/TransferOrder.php
@@ -45,7 +45,7 @@ class TransferOrder extends Order
         }
     }
 
-    public function getOrderTypeName() : string
+    public function getOrderTypeName(): string
     {
         return "Stock Transfer";
     }

--- a/src/Entity/PartnerProfile.php
+++ b/src/Entity/PartnerProfile.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Entity;
 
 use App\Entity\EAV\AttributedEntity;

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -15,12 +15,12 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Product extends CoreEntity
 {
-    const STATUS_ACTIVE = "ACTIVE";
-    const STATUS_INACTIVE = "INACTIVE";
-    const STATUS_OUT_OF_STOCK = "OUT_OF_STOCK";
+    public const STATUS_ACTIVE = "ACTIVE";
+    public const STATUS_INACTIVE = "INACTIVE";
+    public const STATUS_OUT_OF_STOCK = "OUT_OF_STOCK";
 
-    const ROLE_VIEW = "ROLE_PRODUCT_VIEW";
-    const ROLE_EDIT = "ROLE_PRODUCT_EDIT";
+    public const ROLE_VIEW = "ROLE_PRODUCT_VIEW";
+    public const ROLE_EDIT = "ROLE_PRODUCT_EDIT";
 
     /**
      * @var int

--- a/src/Entity/ProductCategory.php
+++ b/src/Entity/ProductCategory.php
@@ -30,7 +30,7 @@ class ProductCategory extends ListOption
         $this->isPartnerOrderable = true;
     }
 
-    public function isPartnerOrderable() : bool
+    public function isPartnerOrderable(): bool
     {
         return $this->isPartnerOrderable;
     }

--- a/src/Entity/Supplier.php
+++ b/src/Entity/Supplier.php
@@ -19,13 +19,13 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Supplier extends CoreEntity
 {
-    const STATUS_ACTIVE = "ACTIVE";
-    const STATUS_INACTIVE = "INACTIVE";
+    public const STATUS_ACTIVE = "ACTIVE";
+    public const STATUS_INACTIVE = "INACTIVE";
 
-    const TYPE_DONOR = "DONOR";
-    const TYPE_VENDOR = "VENDOR";
-    const TYPE_DIAPERDRIVE = "DIAPERDRIVE";
-    const TYPE_DROPSITE = "DROPSITE";
+    public const TYPE_DONOR = "DONOR";
+    public const TYPE_VENDOR = "VENDOR";
+    public const TYPE_DIAPERDRIVE = "DIAPERDRIVE";
+    public const TYPE_DROPSITE = "DROPSITE";
 
     public const ROLE_VIEW = "ROLE_SUPPLIER_VIEW";
     public const ROLE_EDIT = "ROLE_SUPPLIER_EDIT";

--- a/src/Entity/Warehouse.php
+++ b/src/Entity/Warehouse.php
@@ -12,6 +12,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Warehouse extends StorageLocation
 {
-    const ROLE_VIEW = "ROLE_WAREHOUSE_VIEW";
-    const ROLE_EDIT = "ROLE_WAREHOUSE_EDIT";
+    public const ROLE_VIEW = "ROLE_WAREHOUSE_VIEW";
+    public const ROLE_EDIT = "ROLE_WAREHOUSE_EDIT";
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -17,7 +17,7 @@ class Kernel extends BaseKernel
 
     public function registerBundles(): iterable
     {
-        $contents = require $this->getProjectDir().'/config/bundles.php';
+        $contents = require $this->getProjectDir() . '/config/bundles.php';
         foreach ($contents as $class => $envs) {
             if ($envs[$this->environment] ?? $envs['all'] ?? false) {
                 yield new $class();
@@ -32,22 +32,22 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
+        $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
         $container->setParameter('container.dumper.inline_class_loader', true);
-        $confDir = $this->getProjectDir().'/config';
+        $confDir = $this->getProjectDir() . '/config';
 
-        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{packages}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
     }
 
     protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
-        $confDir = $this->getProjectDir().'/config';
+        $confDir = $this->getProjectDir() . '/config';
 
-        $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
     }
 }

--- a/src/Reports/DistributionTotalsExcel.php
+++ b/src/Reports/DistributionTotalsExcel.php
@@ -6,7 +6,6 @@ use App\Entity\Product;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class DistributionTotalsExcel
 {
@@ -37,7 +36,7 @@ class DistributionTotalsExcel
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function buildExcel() : IWriter
+    public function buildExcel(): IWriter
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/src/Reports/PartnerInventoryExcel.php
+++ b/src/Reports/PartnerInventoryExcel.php
@@ -6,7 +6,6 @@ use App\Entity\Product;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class PartnerInventoryExcel
 {
@@ -37,7 +36,7 @@ class PartnerInventoryExcel
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function buildExcel() : IWriter
+    public function buildExcel(): IWriter
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/src/Reports/PartnerInventoryRow.php
+++ b/src/Reports/PartnerInventoryRow.php
@@ -3,8 +3,8 @@
 namespace App\Reports;
 
 use App\Entity\Orders\BulkDistribution;
-use App\Entity\Product;
 use App\Entity\Partner;
+use App\Entity\Product;
 
 /**
  * Class PartnerTotalsRow
@@ -113,7 +113,7 @@ class PartnerInventoryRow
         $inventory = $this->productInventory;
 
         foreach ($this->productForecast as $key => $item) {
-            $forecastKey = "forecast-".$key;
+            $forecastKey = "forecast-" . $key;
             if (!isset($inventory[$key])) {
                 $inventory[$key] = 0;
             }

--- a/src/Reports/PartnerOrderTotalsExcel.php
+++ b/src/Reports/PartnerOrderTotalsExcel.php
@@ -6,7 +6,6 @@ use App\Entity\Product;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class PartnerOrderTotalsExcel
 {
@@ -37,7 +36,7 @@ class PartnerOrderTotalsExcel
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function buildExcel() : IWriter
+    public function buildExcel(): IWriter
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/src/Reports/SupplierTotalsExcel.php
+++ b/src/Reports/SupplierTotalsExcel.php
@@ -6,7 +6,6 @@ use App\Entity\Product;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\IWriter;
-use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class SupplierTotalsExcel
 {
@@ -37,7 +36,7 @@ class SupplierTotalsExcel
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function buildExcel() : IWriter
+    public function buildExcel(): IWriter
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/src/Reports/TransactionExcel.php
+++ b/src/Reports/TransactionExcel.php
@@ -30,7 +30,7 @@ class TransactionExcel
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function buildExcel() : IWriter
+    public function buildExcel(): IWriter
     {
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();

--- a/src/Repository/DefinitionRepository.php
+++ b/src/Repository/DefinitionRepository.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Schedule/ClientExpirationSchedule.php
+++ b/src/Schedule/ClientExpirationSchedule.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Schedule;
 
 use Zenstruck\ScheduleBundle\Schedule;

--- a/src/Security/BulkDistributionVoter.php
+++ b/src/Security/BulkDistributionVoter.php
@@ -10,8 +10,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class BulkDistributionVoter extends Voter
 {
-    const EDIT = 'EDIT';
-    const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
+    public const VIEW = 'VIEW';
 
     protected function supports($attribute, $subject)
     {

--- a/src/Security/BulkDistributionVoter.php
+++ b/src/Security/BulkDistributionVoter.php
@@ -79,7 +79,8 @@ class BulkDistributionVoter extends Voter
         $activePartner = $user->getActivePartner();
 
         // If they have the manage own role, have an active partner, and this order is that partner's, they can edit
-        if ($user->hasRole(Order::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Order::ROLE_MANAGE_OWN)
             && $activePartner
             && $order->getPartner()->getId() === $activePartner->getId()
         ) {

--- a/src/Security/ClientVoter.php
+++ b/src/Security/ClientVoter.php
@@ -70,7 +70,8 @@ class ClientVoter extends Voter
 
         $activePartner = $user->getActivePartner();
 
-        if ($user->hasRole(Client::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Client::ROLE_MANAGE_OWN)
             && $activePartner
             && $client->getPartner()->getId() === $activePartner->getId()
         ) {

--- a/src/Security/ClientVoter.php
+++ b/src/Security/ClientVoter.php
@@ -9,8 +9,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class ClientVoter extends Voter
 {
-    const EDIT = 'EDIT';
-    const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
+    public const VIEW = 'VIEW';
 
     protected function supports($attribute, $subject)
     {

--- a/src/Security/PartnerOrderVoter.php
+++ b/src/Security/PartnerOrderVoter.php
@@ -79,7 +79,8 @@ class PartnerOrderVoter extends Voter
         $activePartner = $user->getActivePartner();
 
         // If they have the manage own role, have an active partner, and this order is that partner's, they can edit
-        if ($user->hasRole(Order::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Order::ROLE_MANAGE_OWN)
             && $activePartner
             && $order->getPartner()->getId() === $activePartner->getId()
         ) {

--- a/src/Security/PartnerOrderVoter.php
+++ b/src/Security/PartnerOrderVoter.php
@@ -10,8 +10,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class PartnerOrderVoter extends Voter
 {
-    const EDIT = 'EDIT';
-    const VIEW = 'VIEW';
+    public const EDIT = 'EDIT';
+    public const VIEW = 'VIEW';
 
     protected function supports($attribute, $subject)
     {

--- a/src/Security/PartnerVoter.php
+++ b/src/Security/PartnerVoter.php
@@ -68,7 +68,8 @@ class PartnerVoter extends Voter
 
         $activePartner = $user->getActivePartner();
 
-        if ($user->hasRole(Partner::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Partner::ROLE_MANAGE_OWN)
             && $activePartner
             && $partner->getPartner()->getId() === $activePartner->getId()
         ) {

--- a/src/Security/SupplierVoter.php
+++ b/src/Security/SupplierVoter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Security;
 
 use App\Entity\Supplier;

--- a/src/Security/UserVoter.php
+++ b/src/Security/UserVoter.php
@@ -2,8 +2,8 @@
 
 namespace App\Security;
 
-use App\Entity\User;
 use App\Entity\Partner;
+use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -55,7 +55,8 @@ class UserVoter extends Voter
 
         $activePartner = $user->getActivePartner();
 
-        if ($user->hasRole(Partner::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Partner::ROLE_MANAGE_OWN)
             && $activePartner
             && $selectedUser->isAssignedToPartner($activePartner)
         ) {
@@ -77,7 +78,8 @@ class UserVoter extends Voter
 
         $activePartner = $user->getActivePartner();
 
-        if ($user->hasRole(Partner::ROLE_MANAGE_OWN)
+        if (
+            $user->hasRole(Partner::ROLE_MANAGE_OWN)
             && $activePartner
             && $selectedUser->isAssignedToPartner($activePartner)
         ) {

--- a/src/Transformers/AdjustmentOrderTransformer.php
+++ b/src/Transformers/AdjustmentOrderTransformer.php
@@ -2,8 +2,8 @@
 
 namespace App\Transformers;
 
-use App\Entity\Orders\AdjustmentOrder;
 use App\Entity\Order;
+use App\Entity\Orders\AdjustmentOrder;
 
 class AdjustmentOrderTransformer extends OrderTransformer
 {
@@ -34,6 +34,6 @@ class AdjustmentOrderTransformer extends OrderTransformer
     {
         $partner = $order->getStorageLocation();
 
-        return $this->item($partner, new StorageLocationTransformer);
+        return $this->item($partner, new StorageLocationTransformer());
     }
 }

--- a/src/Transformers/AttributeDefinitionTransformer.php
+++ b/src/Transformers/AttributeDefinitionTransformer.php
@@ -31,6 +31,6 @@ class AttributeDefinitionTransformer extends TransformerAbstract
     {
         $options = $definition->getOptions();
 
-        return $this->collection($options, new AttributeDefinitionOptionTransformer);
+        return $this->collection($options, new AttributeDefinitionOptionTransformer());
     }
 }

--- a/src/Transformers/AttributeTransformer.php
+++ b/src/Transformers/AttributeTransformer.php
@@ -51,6 +51,6 @@ class AttributeTransformer extends TransformerAbstract
     {
         $options = $attribute->getDefinition()->getOptions();
 
-        return $this->collection($options, new AttributeDefinitionOptionTransformer);
+        return $this->collection($options, new AttributeDefinitionOptionTransformer());
     }
 }

--- a/src/Transformers/BulkDistributionLineItemTransformer.php
+++ b/src/Transformers/BulkDistributionLineItemTransformer.php
@@ -18,6 +18,6 @@ class BulkDistributionLineItemTransformer extends LineItemTransformer
 
     public function includeClient(BulkDistributionLineItem $lineItem)
     {
-        return $this->item($lineItem->getClient(), new ClientTransformer);
+        return $this->item($lineItem->getClient(), new ClientTransformer());
     }
 }

--- a/src/Transformers/BulkDistributionTransformer.php
+++ b/src/Transformers/BulkDistributionTransformer.php
@@ -33,7 +33,7 @@ class BulkDistributionTransformer extends OrderTransformer
     {
         $partner = $order->getPartner();
 
-        return $this->item($partner, new PartnerTransformer);
+        return $this->item($partner, new PartnerTransformer());
     }
 
     /**

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Transformers;
 
 use App\Entity\Client;
-use App\Entity\PartnerProfile;
 use League\Fractal\TransformerAbstract;
 
 class ClientTransformer extends TransformerAbstract
@@ -19,7 +18,7 @@ class ClientTransformer extends TransformerAbstract
             'id' => $client->getUuid(),
             'firstName' => $client->getName()->getFirstname(),
             'lastName' => $client->getName()->getLastname(),
-            'fullName' => $client->getName()->getFirstName().' '.$client->getName()->getLastName(),
+            'fullName' => $client->getName()->getFirstName() . ' ' . $client->getName()->getLastName(),
             'birthdate' => $client->getBirthdate()->format('c'),
             'isExpirationOverridden' => $client->isExpirationOverridden(),
             'ageExpiresAt' => $client->getAgeExpiresAt()->format('c'),

--- a/src/Transformers/InventoryTransactionTransformer.php
+++ b/src/Transformers/InventoryTransactionTransformer.php
@@ -32,20 +32,20 @@ class InventoryTransactionTransformer extends TransformerAbstract
     {
         $lineItem = $inventoryTransaction->getLineItem();
 
-        return $this->item($lineItem, new LineItemTransformer);
+        return $this->item($lineItem, new LineItemTransformer());
     }
 
     public function includeProduct(InventoryTransaction $inventoryTransaction)
     {
         $product = $inventoryTransaction->getProduct();
 
-        return $this->item($product, new ProductTransformer);
+        return $this->item($product, new ProductTransformer());
     }
 
     public function includeStorageLocation(InventoryTransaction $inventoryTransaction)
     {
         $storageLocation = $inventoryTransaction->getStorageLocation();
 
-        return $this->item($storageLocation, new StorageLocationTransformer);
+        return $this->item($storageLocation, new StorageLocationTransformer());
     }
 }

--- a/src/Transformers/LineItemTransformer.php
+++ b/src/Transformers/LineItemTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Transformers;
 
 use App\Entity\LineItem;
-use App\Entity\Product;
 use League\Fractal\TransformerAbstract;
 
 class LineItemTransformer extends TransformerAbstract
@@ -30,20 +29,20 @@ class LineItemTransformer extends TransformerAbstract
     {
         $transactions = $lineItem->getTransactions();
 
-        return $this->collection($transactions, new InventoryTransactionTransformer);
+        return $this->collection($transactions, new InventoryTransactionTransformer());
     }
 
     public function includeProduct(LineItem $lineItem)
     {
         $product = $lineItem->getProduct();
 
-        return $product ? $this->item($product, new ProductTransformer) : null;
+        return $product ? $this->item($product, new ProductTransformer()) : null;
     }
 
     public function includeOrder(LineItem $lineItem)
     {
         $order = $lineItem->getOrder();
 
-        return $this->item($order, new OrderTransformer);
+        return $this->item($order, new OrderTransformer());
     }
 }

--- a/src/Transformers/MerchandiseOrderTransformer.php
+++ b/src/Transformers/MerchandiseOrderTransformer.php
@@ -19,6 +19,6 @@ class MerchandiseOrderTransformer extends OrderTransformer
     {
         $warehouse = $order->getWarehouse();
 
-        return $this->item($warehouse, new StorageLocationTransformer);
+        return $this->item($warehouse, new StorageLocationTransformer());
     }
 }

--- a/src/Transformers/OrderTransformer.php
+++ b/src/Transformers/OrderTransformer.php
@@ -30,6 +30,6 @@ class OrderTransformer extends TransformerAbstract
     {
         $lineItems = $order->getLineItems();
 
-        return $this->collection($lineItems, new LineItemTransformer);
+        return $this->collection($lineItems, new LineItemTransformer());
     }
 }

--- a/src/Transformers/PartnerOrderTransformer.php
+++ b/src/Transformers/PartnerOrderTransformer.php
@@ -35,14 +35,14 @@ class PartnerOrderTransformer extends OrderTransformer
     {
         $partner = $order->getPartner();
 
-        return $this->item($partner, new PartnerTransformer);
+        return $this->item($partner, new PartnerTransformer());
     }
 
     public function includeWarehouse(PartnerOrder $order)
     {
         $warehouse = $order->getWarehouse();
 
-        return $this->item($warehouse, new StorageLocationTransformer);
+        return $this->item($warehouse, new StorageLocationTransformer());
     }
 
     public function includeBags(PartnerOrder $order)

--- a/src/Transformers/StorageLocationTransformer.php
+++ b/src/Transformers/StorageLocationTransformer.php
@@ -37,13 +37,13 @@ class StorageLocationTransformer extends TransformerAbstract
             return;
         }
 
-        return $this->item($address, new AddressTransformer);
+        return $this->item($address, new AddressTransformer());
     }
 
     public function includeContacts(StorageLocation $storageLocation)
     {
         $contacts = $storageLocation->getContacts();
 
-        return $this->collection($contacts, new StorageLocationContactTransformer);
+        return $this->collection($contacts, new StorageLocationContactTransformer());
     }
 }

--- a/src/Transformers/SupplierTransformer.php
+++ b/src/Transformers/SupplierTransformer.php
@@ -30,13 +30,13 @@ class SupplierTransformer extends TransformerAbstract
     {
         $addresses = $supplier->getAddresses();
 
-        return $this->collection($addresses, new SupplierAddressTransformer);
+        return $this->collection($addresses, new SupplierAddressTransformer());
     }
 
     public function includeContacts(Supplier $supplier)
     {
         $contacts = $supplier->getContacts();
 
-        return $this->collection($contacts, new SupplierContactTransformer);
+        return $this->collection($contacts, new SupplierContactTransformer());
     }
 }

--- a/src/Transformers/SupplyOrderTransformer.php
+++ b/src/Transformers/SupplyOrderTransformer.php
@@ -34,7 +34,7 @@ class SupplyOrderTransformer extends OrderTransformer
     {
         $supplier = $order->getSupplier();
 
-        return $this->item($supplier, new SupplierTransformer);
+        return $this->item($supplier, new SupplierTransformer());
     }
 
     public function includeSupplierAddress(SupplyOrder $order)
@@ -42,7 +42,7 @@ class SupplyOrderTransformer extends OrderTransformer
         $supplierAddress = $order->getSupplierAddress();
 
         if ($supplierAddress) {
-            return $this->item($supplierAddress, new SupplierAddressTransformer);
+            return $this->item($supplierAddress, new SupplierAddressTransformer());
         }
     }
 
@@ -50,6 +50,6 @@ class SupplyOrderTransformer extends OrderTransformer
     {
         $warehouse = $order->getWarehouse();
 
-        return $this->item($warehouse, new StorageLocationTransformer);
+        return $this->item($warehouse, new StorageLocationTransformer());
     }
 }

--- a/src/Transformers/TransferOrderTransformer.php
+++ b/src/Transformers/TransferOrderTransformer.php
@@ -20,13 +20,13 @@ class TransferOrderTransformer extends OrderTransformer
     {
         $sourceLocation = $order->getSourceLocation();
 
-        return $this->item($sourceLocation, new StorageLocationTransformer);
+        return $this->item($sourceLocation, new StorageLocationTransformer());
     }
 
     public function includeTargetLocation(TransferOrder $order)
     {
         $targetLocation = $order->getTargetLocation();
 
-        return $this->item($targetLocation, new StorageLocationTransformer);
+        return $this->item($targetLocation, new StorageLocationTransformer());
     }
 }


### PR DESCRIPTION
This starts scanning our codebase against [PSR-12](https://www.php-fig.org/psr/psr-12/). No change is needed to be made on Travis-CI since it is already scanning via php_codesniffer.

PSR-12 is made for PHP 7, whereas PSR-2 (what this PR upgrades) is made for PHP 5.

If you use PHPStorm, you can ensure that you are using PSR-12 as you code via https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer.html