### PR TITLE
173 Status not getting set when creating a client

### DIFF
--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -24,11 +24,19 @@ class Client extends CoreEntity
     use Uuidable;
     use AttributedEntityTrait;
 
+    // State Machine Statuses
     public const STATUS_CREATION = 'CREATION';
     public const STATUS_ACTIVE = 'ACTIVE';
     public const STATUS_INACTIVE = 'INACTIVE';
     public const STATUS_LIMIT_REACHED = 'LIMIT_REACHED';
     public const STATUS_DUPLICATE_INACTIVE = 'DUPLICATE_(INACTIVE)';
+    public const STATUSES = [
+        self::STATUS_CREATION,
+        self::STATUS_ACTIVE,
+        self::STATUS_LIMIT_REACHED,
+        self::STATUS_DUPLICATE_INACTIVE,
+        self::STATUS_INACTIVE,
+    ];
 
     public const TRANSITION_ACTIVATE = 'ACTIVATE';
     public const TRANSITION_DEACTIVATE = 'DEACTIVATE';
@@ -341,8 +349,16 @@ class Client extends CoreEntity
     /**
      * Status is set by the workflow
      */
-    public function setStatus(string $status): void
+    public function setStatus(?string $status): void
     {
+        if (empty($status)) {
+            return;
+        }
+
+        if (!in_array($status, static::STATUSES)) {
+            throw new \Exception(sprintf('%s is not a valid Status', $status));
+        }
+
         $this->status = $status;
     }
 


### PR DESCRIPTION
When a blank status was being sent by the UI, a blank status was getting creating in the DB. Now a check is made for proper statuses being sent and, if none is provided, the default "CREATION" status is used.

Fixes #173 