### PR TITLE
Ensure Partners Can Activate and Deactivate Clients

### DIFF
--- a/src/EventSubscriber/Workflow/ClientSubscriber.php
+++ b/src/EventSubscriber/Workflow/ClientSubscriber.php
@@ -27,7 +27,7 @@ class ClientSubscriber implements EventSubscriberInterface
     public function onTransitionActivate(GuardEvent $event): void
     {
         if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
-            ['status' => $status] = $event->getSubject();
+            $status = $event->getSubject()->getStatus();
 
             if ($status === Client::STATUS_LIMIT_REACHED || $status === Client::STATUS_DUPLICATE_INACTIVE) {
                 $event->setBlocked(true);
@@ -42,7 +42,7 @@ class ClientSubscriber implements EventSubscriberInterface
     public function onTransitionDeactivate(GuardEvent $event): void
     {
         if (!$this->checker->isGranted(Client::ROLE_EDIT_ALL)) {
-            ['status' => $status] = $event->getSubject();
+            $status = $event->getSubject()->getStatus();
 
             if ($status === Client::STATUS_LIMIT_REACHED || $status === Client::STATUS_DUPLICATE_INACTIVE) {
                 $event->setBlocked(true);


### PR DESCRIPTION
Fixes #182 

This was tested by finding an active partner, finding that partner's email address, and logging in as that partner. I then went to Client Management and clicked on a client. I could then transition between only Active and Inactive, no other transitions were available to me as a partner user.