### PR TITLE
changed assertEquels to assertSame

### DIFF
--- a/tests/Controller/ClientControllerTest.php
+++ b/tests/Controller/ClientControllerTest.php
@@ -45,7 +45,7 @@ class ClientControllerTest extends AbstractWebTestCase
 
         $response = $this->getDecodedResponse();
 
-        $this->assertEquals($uuid, $response['id']);
+        $this->assertSame($uuid, $response['id']);
     }
 
     public function testCannotShowBadUuid()
@@ -78,9 +78,9 @@ class ClientControllerTest extends AbstractWebTestCase
 
         $response = $this->getDecodedResponse();
 
-        $this->assertEquals($uuid, $response['id']);
-        $this->assertEquals($firstName, $response['firstName']);
-        $this->assertEquals($newLastName, $response['lastName']);
+        $this->assertSame($uuid, $response['id']);
+        $this->assertSame($firstName, $response['firstName']);
+        $this->assertSame($newLastName, $response['lastName']);
     }
 
     protected function getClientAccount(): Client

--- a/tests/Entity/InventoryTransactionTest.php
+++ b/tests/Entity/InventoryTransactionTest.php
@@ -19,8 +19,8 @@ class InventoryTransactionTest extends AbstractWebTestCase
         $delta                = 1;
         $inventoryTransaction = new InventoryTransaction($storageLocation, $lineItem, $delta);
 
-        $this->assertEquals($product, $inventoryTransaction->getProduct());
-        $this->assertEquals($cost, $inventoryTransaction->getCost());
+        $this->assertSame($product, $inventoryTransaction->getProduct());
+        $this->assertSame($cost, $inventoryTransaction->getCost());
         $this->assertFalse($inventoryTransaction->isCommitted());
     }
 


### PR DESCRIPTION
AssertSame reports an error if the two elements do not share type and value.
For example: this code `$this->assertEquals(3, true);` give uns true, because it won't check the type.

Its saver to use assertSame instead of assertEquels.