### PR TITLE
151 Fix client name sorting

### DIFF
--- a/assets/js/views/client/ClientList.vue
+++ b/assets/js/views/client/ClientList.vue
@@ -121,7 +121,7 @@
                 columns: [
                     //todo: find a better way to sort value objects #30
                     { name: '__checkbox', title: "#" },
-                    { name: '__slot:link', title: "Name", sortField: 'firstname' },
+                    { name: '__slot:link', title: "Name", sortField: 'c.fullName' },
                     { name: 'partner.title', title: "Assigned Partner", sortField: 'partner.title'},
                     { name: 'status', title: "Status", callback: 'statusFormat', sortField: 'status' },
                     { name: 'createdAt', title: "Created", callback: 'dateTimeFormat', sortField: 'createdAt' },

--- a/assets/js/views/client/ClientList.vue
+++ b/assets/js/views/client/ClientList.vue
@@ -121,7 +121,7 @@
                 columns: [
                     //todo: find a better way to sort value objects #30
                     { name: '__checkbox', title: "#" },
-                    { name: '__slot:link', title: "Name", sortField: 'c.fullName' },
+                    { name: '__slot:link', title: "Name", sortField: 'firstname' },
                     { name: 'partner.title', title: "Assigned Partner", sortField: 'partner.title'},
                     { name: 'status', title: "Status", callback: 'statusFormat', sortField: 'status' },
                     { name: 'createdAt', title: "Created", callback: 'dateTimeFormat', sortField: 'createdAt' },

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -3,11 +3,11 @@
 namespace App\Repository;
 
 use App\Entity\Client;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid;
-use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -55,10 +55,15 @@ class ClientRepository extends EntityRepository
         }
 
         if ($sortField) {
-            if (!strstr($sortField, '.')) {
-                $sortField = 'c.' . $sortField;
+            if ($sortField === 'c.fullName') {
+                $qb->orderBy('c.name.firstname', $sortDirection);
+                $qb->orderBy('c.name.lastname', $sortDirection);
+            } else {
+                if (!strstr($sortField, '.')) {
+                    $sortField = 'c.' . $sortField;
+                }
+                $qb->orderBy($sortField, $sortDirection);
             }
-            $qb->orderBy($sortField, $sortDirection);
         }
 
         $this->addCriteria($qb, $params);

--- a/src/Repository/ClientRepository.php
+++ b/src/Repository/ClientRepository.php
@@ -55,13 +55,14 @@ class ClientRepository extends EntityRepository
         }
 
         if ($sortField) {
+            if (!strstr($sortField, '.')) {
+                $sortField = 'c.' . $sortField;
+            }
+
             if ($sortField === 'c.fullName') {
                 $qb->orderBy('c.name.firstname', $sortDirection);
                 $qb->orderBy('c.name.lastname', $sortDirection);
             } else {
-                if (!strstr($sortField, '.')) {
-                    $sortField = 'c.' . $sortField;
-                }
                 $qb->orderBy($sortField, $sortDirection);
             }
         }


### PR DESCRIPTION
At the moment the API responds with status code 500 due to `fullName` not being an actual column. I updated it to sort by `firstname`. 

Should this be `ORDER BY firstname DESC, lastname DESC` instead? However this would create an if clause to the repository class.

I also noticed issue #30 however at the moment I am not sure how to provide a generic solution for all cases. This PR aims to be a quick fix so that the users will not experience unexpected behavior.