### PR TITLE
Add validation logic to product category deletion

### DIFF
--- a/src/Controller/ProductCategoryController.php
+++ b/src/Controller/ProductCategoryController.php
@@ -36,6 +36,9 @@ class ProductCategoryController extends ListOptionController
     /**
      * Delete a ProductCategory
      * @Route(path="/{id<\d+>}", methods={"DELETE"})
+     * @param int $id
+     * @return JsonResponse
+     * @throws UserInterfaceException
      */
     public function destroy(int $id): JsonResponse
     {

--- a/src/Controller/ProductCategoryController.php
+++ b/src/Controller/ProductCategoryController.php
@@ -42,10 +42,13 @@ class ProductCategoryController extends ListOptionController
      */
     public function destroy(int $id): JsonResponse
     {
+        /** @var ProductCategory $productCategory */
+        $productCategory = $this->getListOption($id);
+
         /** @var ProductCategoryRepository $productCategoryRepository */
         $productCategoryRepository = $this->getRepository();
 
-        if (!$productCategoryRepository->isCategoryEmpty($id)) {
+        if (!$productCategoryRepository->isCategoryEmpty($productCategory)) {
             throw new UserInterfaceException('Cannot delete a category which has related products');
         }
 

--- a/src/Controller/ProductCategoryController.php
+++ b/src/Controller/ProductCategoryController.php
@@ -3,8 +3,11 @@
 namespace App\Controller;
 
 use App\Entity\ProductCategory;
+use App\Entity\ProductCategoryRepository;
+use App\Exception\UserInterfaceException;
 use App\Transformers\ProductCategoryTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -28,5 +31,21 @@ class ProductCategoryController extends ListOptionController
     protected function getDefaultTransformer()
     {
         return new ProductCategoryTransformer();
+    }
+
+    /**
+     * Delete a ProductCategory
+     * @Route(path="/{id<\d+>}", methods={"DELETE"})
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        /** @var ProductCategoryRepository $productCategoryRepository */
+        $productCategoryRepository = $this->getRepository();
+
+        if (!$productCategoryRepository->isCategoryEmpty($id)) {
+            throw new UserInterfaceException('Cannot delete a category which has related products');
+        }
+
+        return parent::destroy($id);
     }
 }

--- a/src/Entity/ProductCategory.php
+++ b/src/Entity/ProductCategory.php
@@ -8,7 +8,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 /**
  * Class Product
  *
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="App\Entity\ProductCategoryRepository")
  * @Gedmo\SoftDeleteable(fieldName="deletedAt", timeAware=false)
  */
 class ProductCategory extends ListOption

--- a/src/Entity/ProductCategoryRepository.php
+++ b/src/Entity/ProductCategoryRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\EntityRepository;
+
+class ProductCategoryRepository extends EntityRepository
+{
+    public function isCategoryEmpty(int $categoryId): bool
+    {
+        $product = $this->getEntityManager()
+            ->createQueryBuilder()
+            ->select('p')
+            ->from(Product::class, 'p')
+            ->join('p.productCategory', 'pc')
+            ->andWhere('p.deletedAt IS NULL')
+            ->andWhere('pc.id = :categoryId')
+            ->setMaxResults(1)
+            ->setParameter('categoryId', $categoryId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $product === null;
+    }
+}

--- a/src/Entity/ProductCategoryRepository.php
+++ b/src/Entity/ProductCategoryRepository.php
@@ -6,20 +6,17 @@ use Doctrine\ORM\EntityRepository;
 
 class ProductCategoryRepository extends EntityRepository
 {
-    public function isCategoryEmpty(int $categoryId): bool
+    public function isCategoryEmpty(ProductCategory $productCategory): bool
     {
-        $product = $this->getEntityManager()
+        $productCount = $this->getEntityManager()
             ->createQueryBuilder()
-            ->select('p')
+            ->select('count(p)')
             ->from(Product::class, 'p')
-            ->join('p.productCategory', 'pc')
-            ->andWhere('p.deletedAt IS NULL')
-            ->andWhere('pc.id = :categoryId')
-            ->setMaxResults(1)
-            ->setParameter('categoryId', $categoryId)
+            ->andWhere('p.productCategory = :productCategory')
+            ->setParameter('productCategory', $productCategory)
             ->getQuery()
-            ->getOneOrNullResult();
+            ->getSingleScalarResult();
 
-        return $product === null;
+        return $productCount === 0;
     }
 }


### PR DESCRIPTION
As discussed under #216 I have added some validation logic for deleting the ProductCategory entity.

When ProductCategory has related Product entities which have not been deleted then the user will be presented with the following error: Cannot delete a category which has related products