### PR TITLE
#10 Show menu items only if the user has access to them

### DIFF
--- a/assets/js/components/ProductSelectionField.vue
+++ b/assets/js/components/ProductSelectionField.vue
@@ -11,7 +11,7 @@
         />
         <span
             v-else
-            v-text="value.title"
+            v-text="value.name"
         />
     </div>
 </template>

--- a/assets/js/components/Sidebar.vue
+++ b/assets/js/components/Sidebar.vue
@@ -9,7 +9,7 @@
                 :key="menu.id"
                 :class="{ treeview: menu.hasOwnProperty('links') }"
             >
-                <router-link :to="menu.route || '#'">
+                <router-link :to="menu.route || '#'" v-if="menuHasAccessibleLinks(menu)">
                     <i
                         v-if="menu.icon"
                         class="fa"
@@ -121,7 +121,7 @@ export default {
         methods: {
             routesUserCanAccess(links) {
                 return links.filter((link) => {
-                    let resolved = this.$router.resolve({name: link.name});
+                    let resolved = this.$router.resolve(link.route);
                     let route = resolved.route;
                     if (route?.meta?.roles) {
                         let hasRoles = route.meta.roles.filter((role) => this.$store.getters.userHasRole(role));
@@ -129,7 +129,14 @@ export default {
                     }
                     return true;
                 }, this);
-            }
+            },
+            menuHasAccessibleLinks(menu) {
+                if (menu.hasOwnProperty('links')) {
+                    return this.routesUserCanAccess(menu.links).length > 0;
+                } else {
+                    return true;
+                }
+            },
         }
     }
 </script>

--- a/assets/js/routes.js
+++ b/assets/js/routes.js
@@ -258,7 +258,7 @@ let routes = [
         path: '/orders/distribution/:id',
         name: 'order-distribution-edit',
         component: require('./views/order/distribution/BulkDistributionOrderEdit.vue').default,
-        meta: {roles: ['ROLE_DISTRIBUTION_ORDER_EDIT', 'ROLE_DISTRIBUTION_ORDER_MANAGE_OWN']}
+        meta: {roles: ['ROLE_DISTRIBUTION_ORDER_EDIT', 'ROLE_ORDER_MANAGE_OWN']}
     },
 
     {
@@ -330,7 +330,8 @@ let routes = [
     {
         path: '/reports/supply-totals',
         name: 'reports-supply-totals',
-        component: require('./views/reports/SupplyTotalsReport.vue').default
+        component: require('./views/reports/SupplyTotalsReport.vue').default,
+        meta: { roles: ['ROLE_SUPPLIER_VIEW']}
     },
     {
         path: '/reports/distribution-totals',

--- a/assets/js/views/order/distribution/BulkDistributionLineItemFormRow.vue
+++ b/assets/js/views/order/distribution/BulkDistributionLineItemFormRow.vue
@@ -15,6 +15,7 @@
                 <ProductSelectionField
                     v-model="value.product"
                     :label="false"
+                    :editable="editable"
                 />
             </div>
             <div


### PR DESCRIPTION
Closes #10 

The logic for showing menu items base on the user's role wasn't working right. We were also showing the 1st level nav even if it didn't have any sub-menu items.

Bonus product selection component fixes.