### PR TITLE
195 partner review

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -59,11 +59,9 @@ Vue.directive('datepicker', {
     inserted: function(el, binding, vnode) {
         binding.value = binding.value || {};
         let format = binding.value.format || 'YYYY-MM-DD';
-        let value = moment($(el).val(), format);
+        let tz = binding.value.tz || null;
+        let value = moment.tz($(el).val(), format, tz);
 
-        if (binding.value.tz || false) {
-            value.tz(binding.value.tz);
-        }
         jQuery(el).datetimepicker({
             format: format
         }).on('dp.change', function (e) {
@@ -74,10 +72,8 @@ Vue.directive('datepicker', {
     componentUpdated: function(el, binding) {
         binding.value = binding.value || {};
         let format = binding.value.format || 'YYYY-MM-DD';
-        let value = moment(el.value, format);
-        if (binding.value.tz || false) {
-            value.tz(binding.value.tz);
-        }
+        let tz = binding.value.tz || null;
+        let value = moment.tz(el.value, format, tz);
         jQuery(el).data("DateTimePicker").date(value);
     }
 });

--- a/assets/js/components/OrderMetadataBox.vue
+++ b/assets/js/components/OrderMetadataBox.vue
@@ -32,7 +32,7 @@
                     v-if="editable"
                     v-model="order.orderPeriod"
                     label="Order Period:"
-                    format="YYYY-MM-DD"
+                    format="YYYY-MM"
                     timezone="Etc/UTC"
                 />
 

--- a/assets/js/components/PartnerSelectionForm.vue
+++ b/assets/js/components/PartnerSelectionForm.vue
@@ -5,7 +5,7 @@
                 v-if="editable"
                 ref="partnerSelect"
                 v-model="value"
-                :preloaded-options="allActivePartners"
+                :preloaded-options="allPartners"
                 display-property="title"
                 empty-string="-- Select Partner --"
                 :label="label"
@@ -43,7 +43,7 @@
             label: { type: String, default: "Partner" },
         },
         computed: mapGetters([
-            'allActivePartners'
+            'allPartners'
         ]),
         mounted: function () {
             this.$store.dispatch('loadStorageLocations');

--- a/assets/js/store/modules/storageLocations.js
+++ b/assets/js/store/modules/storageLocations.js
@@ -19,6 +19,12 @@ const getters = {
             .sort((a,b) => a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1);
         return active;
     },
+    allPartners: state => {
+        let active = [...state.all]
+            .filter(storageLocation => storageLocation.type !== 'Warehouse')
+            .sort((a,b) => a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1);
+        return active;
+    },
     allActiveWarehouses: state => {
         let active = [...state.all]
             .filter(storageLocation => storageLocation.status === "ACTIVE" && storageLocation.type === 'Warehouse')

--- a/assets/js/views/admin/ConfigurationEdit.vue
+++ b/assets/js/views/admin/ConfigurationEdit.vue
@@ -13,8 +13,8 @@
             Configuration
         </h3>
 
-        <div class="row">
-            <form role="form">
+        <form role="form">
+            <div class="row">
                 <div class="col-md-6">
                     <div class="box box-info">
                         <div class="box-header with-border">
@@ -33,7 +33,98 @@
                         </div>
                         <!-- /.box-body -->
                     </div>
+
+                    <div class="box box-info">
+                        <div class="box-header with-border">
+                            <h3 class="box-title">
+                                <i class="icon fa fa-calendar fa-fw" />Annual Review Process
+                            </h3>
+                        </div>
+                        <!-- /.box-header -->
+                        <div class="box-body">
+                            <!-- text input -->
+
+                            <div class="panel box box-primary">
+                                <div class="box-header with-border">
+                                    <h4 class="box-title">
+                                        Partner Annual Review
+                                    </h4>
+                                </div>
+                                <div class="box-body">
+                                    <div class="row">
+                                        <DateField
+                                            v-model="settings.partnerReviewStart"
+                                            label="Partner Review Period Start Day"
+                                            format="MM/DD"
+                                            class="col-xs-6"
+                                        />
+                                        <DateField
+                                            v-model="settings.partnerReviewEnd"
+                                            label="Partner Review Period Ends Day"
+                                            format="MM/DD"
+                                            class="col-xs-6"
+                                        />
+                                    </div>
+                                    <div class="row">
+                                        <DateField
+                                            v-model="settings.partnerReviewLastStartRun"
+                                            label="Last Successful Partner Review Start Process"
+                                            format="MM/DD/YYYY h:mm:ss a"
+                                            class="col-xs-6"
+                                        />
+                                        <DateField
+                                            v-model="settings.partnerReviewLastEndRun"
+                                            label="Last Successful Partner Review End Process"
+                                            format="MM/DD/YYYY h:mm:ss a"
+                                            class="col-xs-6"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+
+                            <div class="panel box box-success">
+                                <div class="box-header with-border">
+                                    <h4 class="box-title">
+                                        Client Annual Review
+                                    </h4>
+                                </div>
+                                <div class="box-body">
+                                    <div class="row">
+                                        <DateField
+                                            v-model="settings.clientReviewStart"
+                                            label="Client Review Period Start Day"
+                                            format="MM/DD"
+                                            class="col-xs-6"
+                                        />
+                                        <DateField
+                                            v-model="settings.clientReviewEnd"
+                                            label="Client Review Period End Day"
+                                            format="MM/DD"
+                                            class="col-xs-6"
+                                        />
+                                    </div>
+                                    <div class="row">
+                                        <DateField
+                                            v-model="settings.clientrReviewLastStartRun"
+                                            label="Last Successful Client Review Start Process"
+                                            format="MM/DD/YYYY h:mm:ss a"
+                                            class="col-xs-6"
+                                        />
+                                        <DateField
+                                            v-model="settings.clientReviewLastEndRun"
+                                            label="Last Successful Client Review End Process"
+                                            format="MM/DD/YYYY h:mm:ss a"
+                                            class="col-xs-6"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.box-body -->
+                    </div>
                 </div>
+
                 <div class="col-md-6">
                     <div class="box box-info">
                         <div class="box-header with-border">
@@ -51,9 +142,8 @@
                         <!-- /.box-body -->
                     </div>
                 </div>
-
-            </form>
-        </div>
+            </div>
+        </form>
     </section>
 </template>
 
@@ -61,15 +151,24 @@
     import { mapGetters } from 'vuex'
     import OptionListStatic from "../../components/OptionListStatic";
     import StateField from "../../components/StateField";
+    import DateField from "../../components/DateField";
 
     export default {
         name: "ConfigurationEdit",
-        components: {StateField, OptionListStatic},
+        components: {DateField, StateField, OptionListStatic},
         data() {
             return {
                 settings: {
                     pullupCategory: "",
                     zipCountyStates: [],
+                    partnerReviewStart: null,
+                    partnerReviewEnd: null,
+                    partnerReviewLastStartRun: null,
+                    partnerReviewLastEndRun: null,
+                    clientReviewStart: null,
+                    clientReviewEnd: null,
+                    clientReviewLastStartRun: null,
+                    clientReviewLastEndRun: null,
                 }
             }
         },

--- a/assets/js/views/admin/ConfigurationEdit.vue
+++ b/assets/js/views/admin/ConfigurationEdit.vue
@@ -106,7 +106,7 @@
                                     </div>
                                     <div class="row">
                                         <DateField
-                                            v-model="settings.clientrReviewLastStartRun"
+                                            v-model="settings.clientReviewLastStartRun"
                                             label="Last Successful Client Review Start Process"
                                             format="MM/DD/YYYY h:mm:ss a"
                                             class="col-xs-6"

--- a/assets/js/views/order/partner/PartnerOrderEdit.vue
+++ b/assets/js/views/order/partner/PartnerOrderEdit.vue
@@ -62,6 +62,7 @@
                                 <partnerselectionform
                                     ref="partnerSelection"
                                     v-model="order.partner"
+                                    :label="false"
                                     :editable="order.isEditable"
                                     @change="$v.order.partner.$touch()"
                                     @loaded="$v.order.partner.$reset()"

--- a/assets/js/views/order/partner/PartnerOrderEdit.vue
+++ b/assets/js/views/order/partner/PartnerOrderEdit.vue
@@ -128,6 +128,9 @@
             :action="this.save"
             :order-title="order.sequence"
         />
+        <Modal classes="modal-danger" title="Partner not active" id="inactive-partner-modal" :has-action="false">
+            This partner is not in an active status and cannot place an order at this time.
+        </Modal>
     </section>
 </template>
 
@@ -143,8 +146,10 @@
     import WarehouseSelectionForm from '../../../components/WarehouseSelectionForm.vue'
     import LineItemForm from '../../../components/LineItemForm.vue';
     import PartnerSelectionForm from '../../../components/PartnerSelectionForm.vue';
+    import Modal from "../../../components/Modal";
     export default {
         components: {
+            Modal,
             'modalcomplete' : ModalOrderConfirmComplete,
             'modaldelete' : ModalOrderConfirmDelete,
             'modalinvalid' : ModalOrderInvalid,
@@ -263,6 +268,9 @@
             },
             onPartnerChange: function(currentPartner) {
                 this.partnerType = currentPartner.partnerType;
+                if(!currentPartner.canPlaceOrders && this.new) {
+                    $('#inactive-partner-modal').modal('show');
+                }
             }
         }
     }

--- a/assets/sass/_happybottoms.scss
+++ b/assets/sass/_happybottoms.scss
@@ -1,3 +1,7 @@
+hr {
+    border-color: #f4f4f4;
+}
+
 .loadingArea {
     text-align: center;
 }

--- a/config/packages/workflow.php
+++ b/config/packages/workflow.php
@@ -67,11 +67,8 @@ $container->loadFromExtension('framework', [
                         'title' => 'Flag for Review'
                     ],
                     'from' => [
-                        Partner::STATUS_APPLICATION_PENDING,
-                        Partner::STATUS_APPLICATION_PENDING_PRIORITY,
                         Partner::STATUS_ACTIVE,
                         Partner::STATUS_REVIEW_PAST_DUE,
-                        Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_NEEDS_PROFILE_REVIEW,
                 ],
@@ -80,11 +77,7 @@ $container->loadFromExtension('framework', [
                         'title' => 'Flag for Review Past Due'
                     ],
                     'from' => [
-                        Partner::STATUS_APPLICATION_PENDING,
-                        Partner::STATUS_APPLICATION_PENDING_PRIORITY,
-                        Partner::STATUS_ACTIVE,
                         Partner::STATUS_NEEDS_PROFILE_REVIEW,
-                        Partner::STATUS_INACTIVE,
                     ],
                     'to' => Partner::STATUS_REVIEW_PAST_DUE,
                 ],

--- a/config/packages/workflow.php
+++ b/config/packages/workflow.php
@@ -62,6 +62,16 @@ $container->loadFromExtension('framework', [
                     ],
                     'to' => Partner::STATUS_ACTIVE,
                 ],
+                Partner::TRANSITION_REVIEWED => [
+                    'metadata' => [
+                        'title' => 'Reviewed'
+                    ],
+                    'from' => [
+                        Partner::STATUS_NEEDS_PROFILE_REVIEW,
+                        Partner::STATUS_REVIEW_PAST_DUE,
+                    ],
+                    'to' => Partner::STATUS_ACTIVE,
+                ],
                 Partner::TRANSITION_FLAG_FOR_REVIEW => [
                     'metadata' => [
                         'title' => 'Flag for Review'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,11 @@ services:
         tags:
             - { name: doctrine.event_subscriber }
 
+    app.listener.partner:
+        class: App\Listener\PartnerListener
+        tags:
+            - { name: doctrine.event_subscriber }
+
     sam_j_fractal.manager:
         class: SamJ\FractalBundle\ContainerAwareManager
         public: true

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2611,16 +2611,6 @@ parameters:
 			path: src/Entity/Sequence.php
 
 		-
-			message: "#^Property App\\\\Entity\\\\Setting\\:\\:\\$value type mapping mismatch\\: database can contain array but property expects string\\.$#"
-			count: 1
-			path: src/Entity/Setting.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\Setting\\:\\:\\$value type mapping mismatch\\: property can contain string but database expects array\\.$#"
-			count: 1
-			path: src/Entity/Setting.php
-
-		-
 			message: "#^Property App\\\\Entity\\\\StorageLocation\\:\\:\\$address type mapping mismatch\\: database can contain App\\\\Entity\\\\StorageLocationAddress\\|null but property expects App\\\\Entity\\\\StorageLocationAddress\\.$#"
 			count: 1
 			path: src/Entity/StorageLocation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3516,11 +3516,6 @@ parameters:
 			path: src/Repository/ZipCountyRepository.php
 
 		-
-			message: "#^Parameter \\#1 \\$time of method Zenstruck\\\\ScheduleBundle\\\\Schedule\\\\Task\\:\\:at\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Schedule/ClientExpirationSchedule.php
-
-		-
 			message: "#^Method App\\\\Security\\\\AdjustmentOrderVoter\\:\\:canView\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/Security/AdjustmentOrderVoter.php

--- a/src/Command/ClientExpirationCommand.php
+++ b/src/Command/ClientExpirationCommand.php
@@ -78,7 +78,7 @@ class ClientExpirationCommand extends Command
 
         $rows = array_merge($ageRows, $distRows);
 
-        $io->table($headers, array_merge($ageRows, $rows));
+        $io->table($headers, $rows);
 
         if ($force) {
             foreach ($agedOutClients as $client) {

--- a/src/Command/PartnerAnnualReviewCommand.php
+++ b/src/Command/PartnerAnnualReviewCommand.php
@@ -38,8 +38,12 @@ class PartnerAnnualReviewCommand extends Command
 
     private $tokenStorage;
 
-    public function __construct(EntityManagerInterface $em, Registry $workflowRegistry, AppConfiguration $appConfiguration, TokenStorageInterface $storage)
-    {
+    public function __construct(
+        EntityManagerInterface $em,
+        Registry $workflowRegistry,
+        AppConfiguration $appConfiguration,
+        TokenStorageInterface $storage
+    ) {
         $this->em = $em;
         $this->workflowRegistry = $workflowRegistry;
         $this->appConfig = $appConfiguration;
@@ -122,10 +126,11 @@ class PartnerAnnualReviewCommand extends Command
                     $this->appConfig->set('partnerReviewLastStartRun', $now->format());
                 }
             }
-        }
-        // We are passed the end of the review period, but have not completed it
-        elseif ($now->isAfter($end) && $lastEnd->isBefore($end)) {
-            $activePartners = $this->em->getRepository(Partner::class)->findBy(['status' => Partner::STATUS_NEEDS_PROFILE_REVIEW]);
+        } elseif ($now->isAfter($end) && $lastEnd->isBefore($end)) {
+            // We are passed the end of the review period, but have not completed it
+            $activePartners = $this->em
+                ->getRepository(Partner::class)
+                ->findBy(['status' => Partner::STATUS_NEEDS_PROFILE_REVIEW]);
 
             foreach ($activePartners as $partner) {
                 $rows[] = [

--- a/src/Command/PartnerAnnualReviewCommand.php
+++ b/src/Command/PartnerAnnualReviewCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Client;
+use App\Entity\Partner;
+use App\Entity\Setting;
+use Doctrine\ORM\EntityManagerInterface;
+use Moment\Moment;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Workflow\Registry;
+
+class PartnerAnnualReviewCommand extends Command
+{
+    protected static $defaultName = 'app:partner-review:run';
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    /**
+     * @var Registry
+     */
+    private $workflowRegistry;
+
+    public function __construct(EntityManagerInterface $em, Registry $workflowRegistry)
+    {
+        $this->em = $em;
+        $this->workflowRegistry = $workflowRegistry;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Run the partner annual review job.')
+            ->addOption(
+                'force',
+                null,
+                InputOption::VALUE_NONE,
+                'Execute transitions on partners need to be moved if we are in the review window.'
+            )
+        ;
+    }
+
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $force = $input->getOption('force') !== false;
+        $io = new SymfonyStyle($input, $output);
+        $partnerRepo = $this->em->getRepository(Partner::class);
+
+        $settingsRepo = $this->em->getRepository(Setting::class);
+
+        $now = new Moment('now');
+
+        $start = new Moment($settingsRepo->find('partnerReviewStart')->getValue());
+        $start->setYear($now->getYear());
+        $end = new Moment($settingsRepo->find('partnerReviewEnd')->getValue());
+        $end->setYear($now->getYear());
+
+        $lastStart = new Moment($settingsRepo->find('partnerReviewLastStartRun')->getValue());
+        $lastEnd = new Moment($settingsRepo->find('partnerReviewLastEndRun')->getValue());
+
+        if(!$now->isBetween($start, $end) && $lastEnd->isAfter($end)) {
+            return;
+        }
+
+
+        if ($lastStart->isBefore($start)) {
+            $activePartners = $this->em->getRepository(Partner::class)->findBy(['status' => Partner::STATUS_ACTIVE]);
+
+            foreach ($activePartners as $partner) {
+                $this->workflowRegistry
+                    ->get($partner)
+                    ->apply($partner, Partner::TRANSITION_FLAG_FOR_REVIEW);
+            }
+
+            $this->em->flush();
+        }
+        else if ($now->isAfter($end) && $lastEnd->isBefore($end)) {
+            $activePartners = $this->em->getRepository(Partner::class)->findBy(['status' => Partner::STATUS_NEEDS_PROFILE_REVIEW]);
+
+            foreach ($activePartners as $partner) {
+                $this->workflowRegistry
+                    ->get($partner)
+                    ->apply($partner, Partner::TRANSITION_FLAG_FOR_REVIEW_PAST_DUE);
+            }
+
+            $this->em->flush();
+
+        }
+
+    }
+
+}

--- a/src/Command/PartnerAnnualReviewCommand.php
+++ b/src/Command/PartnerAnnualReviewCommand.php
@@ -59,7 +59,7 @@ class PartnerAnnualReviewCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Run the partner annual review job.')
@@ -85,9 +85,9 @@ class PartnerAnnualReviewCommand extends Command
         $now = new Moment('now');
 
         $start = new Moment($this->appConfig->get('partnerReviewStart'));
-        $start->setYear($now->getYear());
+        $start->setYear((int) $now->getYear());
         $end = new Moment($this->appConfig->get('partnerReviewEnd'));
-        $end->setYear($now->getYear());
+        $end->setYear((int) $now->getYear());
 
         $lastStart = new Moment($this->appConfig->get('partnerReviewLastStartRun'));
         $lastEnd = new Moment($this->appConfig->get('partnerReviewLastEndRun'));
@@ -95,7 +95,7 @@ class PartnerAnnualReviewCommand extends Command
         // We are not in a review period and we've finished the previous period
         if(!$now->isBetween($start, $end) && $lastEnd->isAfter($end)) {
             $io->success('No Partner Review action needed at this time.');
-            return;
+            return 0;
         }
 
         $io->text(sprintf('Partner Review Period: %s - %s', $start->format(), $end->format()));

--- a/src/Command/PartnerAnnualReviewCommand.php
+++ b/src/Command/PartnerAnnualReviewCommand.php
@@ -52,7 +52,8 @@ class PartnerAnnualReviewCommand extends Command
             'system',
             null,
             'main',
-            Group::AVAILABLE_ROLES);
+            Group::AVAILABLE_ROLES
+        );
 
         $this->tokenStorage->setToken($token);
 
@@ -93,7 +94,7 @@ class PartnerAnnualReviewCommand extends Command
         $lastEnd = new Moment($this->appConfig->get('partnerReviewLastEndRun'));
 
         // We are not in a review period and we've finished the previous period
-        if(!$now->isBetween($start, $end) && $lastEnd->isAfter($end)) {
+        if (!$now->isBetween($start, $end) && $lastEnd->isAfter($end)) {
             $io->success('No Partner Review action needed at this time.');
             return 0;
         }
@@ -117,13 +118,13 @@ class PartnerAnnualReviewCommand extends Command
                     ->get($partner)
                     ->apply($partner, Partner::TRANSITION_FLAG_FOR_REVIEW);
 
-                if($force) {
+                if ($force) {
                     $this->appConfig->set('partnerReviewLastStartRun', $now->format());
                 }
             }
         }
         // We are passed the end of the review period, but have not completed it
-        else if ($now->isAfter($end) && $lastEnd->isBefore($end)) {
+        elseif ($now->isAfter($end) && $lastEnd->isBefore($end)) {
             $activePartners = $this->em->getRepository(Partner::class)->findBy(['status' => Partner::STATUS_NEEDS_PROFILE_REVIEW]);
 
             foreach ($activePartners as $partner) {
@@ -137,7 +138,7 @@ class PartnerAnnualReviewCommand extends Command
                     ->get($partner)
                     ->apply($partner, Partner::TRANSITION_FLAG_FOR_REVIEW_PAST_DUE);
 
-                if($force) {
+                if ($force) {
                     $this->appConfig->set('partnerReviewLastEndRun', $now->format());
                 }
             }
@@ -151,7 +152,7 @@ class PartnerAnnualReviewCommand extends Command
 
         $io->table($headers, $rows);
 
-        if($force) {
+        if ($force) {
             $this->em->flush();
         } else {
             $io->warning(sprintf(
@@ -162,5 +163,4 @@ class PartnerAnnualReviewCommand extends Command
 
         return 0;
     }
-
 }

--- a/src/Command/PartnerAnnualReviewCommand.php
+++ b/src/Command/PartnerAnnualReviewCommand.php
@@ -50,8 +50,6 @@ class PartnerAnnualReviewCommand extends Command
 
         $this->tokenStorage = $storage;
 
-        $user = $this->em->getRepository(User::class)->find(906);
-
         $token = new UsernamePasswordToken(
             'system',
             null,

--- a/src/Configuration/AppConfiguration.php
+++ b/src/Configuration/AppConfiguration.php
@@ -47,10 +47,12 @@ class AppConfiguration
         $this->em = $em;
     }
 
-    public function hasSettingId(string $settingId) : bool
+    public function hasSettingId(string $settingId): bool
     {
         // Early return if we know the key exists, but if it doesn't we may still need to check the database
-        if (array_key_exists($settingId, $this->cache)) return true;
+        if (array_key_exists($settingId, $this->cache)) {
+            return true;
+        }
 
         $entry = $this->getRepository()->find($settingId);
         if ($entry) {
@@ -77,7 +79,9 @@ class AppConfiguration
 
         $entry->setValue($value);
 
-        if ($this->autoFlush) $this->em->flush();
+        if ($this->autoFlush) {
+            $this->em->flush();
+        }
     }
 
     /**
@@ -88,7 +92,9 @@ class AppConfiguration
      */
     public function create(string $settingId, $value): void
     {
-        if ($this->hasSettingId($settingId)) throw new \InvalidArgumentException(sprintf('setting "%s" already exists', $settingId));
+        if ($this->hasSettingId($settingId)) {
+            throw new \InvalidArgumentException(sprintf('setting "%s" already exists', $settingId));
+        }
 
         $entry = new Setting();
         $entry->setConfig($settingId);
@@ -98,7 +104,9 @@ class AppConfiguration
 
         if ($this->em instanceof EntityManagerInterface) {
             $this->em->persist($entry);
-            if ($this->autoFlush) $this->em->flush();
+            if ($this->autoFlush) {
+                $this->em->flush();
+            }
         }
     }
 
@@ -116,7 +124,9 @@ class AppConfiguration
         }
 
         $entry = $this->getRepository()->find($settingId);
-        if (!$entry) return null;
+        if (!$entry) {
+            return null;
+        }
         $this->cache[$settingId] = $entry->getValue();
 
         return $this->cache[$settingId] ?? null;

--- a/src/Configuration/AppConfiguration.php
+++ b/src/Configuration/AppConfiguration.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Configuration;
+
+use App\Entity\Setting;
+use App\Repository\SettingRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Service to read application settings
+ *
+ * If an EntityManagerInterface is provided settings will be read and written
+ * to the database.
+ */
+class AppConfiguration
+{
+    /**
+     * Persists config to the database. Service is optional for a few reasons:
+     *
+     * - Makes testing a lot easier.
+     * - This service could be used for initial application setup before the
+     *   database connection information is defined.
+     *
+     * @var null|EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * Cache of settings to reduce database interactions.
+     *
+     * @var mixed[]
+     */
+    protected $cache = [];
+
+    /**
+     * When true, configuration changes are immediately committed to the
+     * database with flush().
+     *
+     * When false, application code must explicitly call EM->flush().
+     *
+     * @var bool
+     */
+    protected $autoFlush = true;
+
+    public function __construct(EntityManagerInterface $em = null)
+    {
+        $this->em = $em;
+    }
+
+    public function hasSettingId(string $settingId) : bool
+    {
+        // Early return if we know the key exists, but if it doesn't we may still need to check the database
+        if (array_key_exists($settingId, $this->cache)) return true;
+
+        if ($this->em) {
+            $entry = $this->getRepository()->find($settingId);
+            if ($entry) {
+                $this->cache[$settingId] = $entry->getValue();
+            }
+        }
+
+        return array_key_exists($settingId, $this->cache);
+    }
+
+    public function set(string $settingId, $value)
+    {
+        $this->cache[$settingId] = $value;
+
+        if ($this->em) {
+            $entry = $this->getRepository()->find($settingId);
+            if (!$entry) {
+                $entry = new Setting();
+                $entry->setConfig($settingId);
+                $this->em->persist($entry);
+            }
+
+            $entry->setValue($value);
+
+            if ($this->autoFlush) $this->em->flush();
+        }
+    }
+
+    /**
+     * This method throws an exception if $settingId is already defined
+     */
+    public function create(string $settingId, $value)
+    {
+        if ($this->hasSettingId($settingId)) throw new \InvalidArgumentException(sprintf('setting "%s" already exists', $settingId));
+
+        $entry = new Setting();
+        $entry->setConfig($settingId);
+        $entry->setValue($value);
+
+        $this->cache[$settingId] = $entry->getValue();
+
+        if ($this->em) {
+            $this->em->persist($entry);
+            if ($this->autoFlush) $this->em->flush();
+        }
+    }
+
+    /**
+     * Returns the value for $reference ID or null if it doesn't exist
+     *
+     * If you need to check whether a setting exists, see hasReferenceId()
+     *
+     * @return mixed|null
+     */
+    public function get(string $settingId)
+    {
+        if (array_key_exists($settingId, $this->cache)) {
+            return $this->cache[$settingId];
+        }
+
+        if ($this->em) {
+            $entry = $this->getRepository()->find($settingId);
+            if (!$entry) return null;
+            $this->cache[$settingId] = $entry->getValue();
+        }
+
+        return $this->cache[$settingId] ?? null;
+    }
+
+    protected function getRepository(): SettingRepository
+    {
+        return $this->em->getRepository(Setting::class);
+    }
+
+    public function getAutoFlush(): bool
+    {
+        return $this->autoFlush;
+    }
+
+    public function setAutoFlush(bool $autoFlush, bool $flushNow = true): void
+    {
+        $this->autoFlush = $autoFlush;
+
+        if ($flushNow && $this->em) {
+            $this->em->flush();
+        }
+    }
+}

--- a/src/Controller/PartnerOrderController.php
+++ b/src/Controller/PartnerOrderController.php
@@ -7,6 +7,7 @@ use App\Entity\Orders\PartnerOrderLineItem;
 use App\Entity\Partner;
 use App\Entity\User;
 use App\Entity\Warehouse;
+use App\Exception\UserInterfaceException;
 use App\Transformers\BagTransformer;
 use App\Transformers\PartnerOrderTransformer;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
@@ -41,6 +42,7 @@ class PartnerOrderController extends OrderController
      *
      * @param Request $request
      * @return JsonResponse
+     * @throws UserInterfaceException
      */
     public function store(Request $request)
     {
@@ -55,6 +57,11 @@ class PartnerOrderController extends OrderController
 
         if ($params['partner']['id']) {
             $newPartner = $this->getEm()->find(Partner::class, $params['partner']['id']);
+
+            if(!$newPartner->canPlaceOrders()) {
+                throw new UserInterfaceException(sprintf('%s is not in an allowed status to place new orders.', $newPartner->getTitle()));
+            }
+
             $order->setPartner($newPartner);
         }
 

--- a/src/Controller/PartnerOrderController.php
+++ b/src/Controller/PartnerOrderController.php
@@ -58,7 +58,7 @@ class PartnerOrderController extends OrderController
         if ($params['partner']['id']) {
             $newPartner = $this->getEm()->find(Partner::class, $params['partner']['id']);
 
-            if(!$newPartner->canPlaceOrders()) {
+            if (!$newPartner->canPlaceOrders()) {
                 throw new UserInterfaceException(sprintf('%s is not in an allowed status to place new orders.', $newPartner->getTitle()));
             }
 

--- a/src/Controller/PartnerOrderController.php
+++ b/src/Controller/PartnerOrderController.php
@@ -59,7 +59,9 @@ class PartnerOrderController extends OrderController
             $newPartner = $this->getEm()->find(Partner::class, $params['partner']['id']);
 
             if (!$newPartner->canPlaceOrders()) {
-                throw new UserInterfaceException(sprintf('%s is not in an allowed status to place new orders.', $newPartner->getTitle()));
+                throw new UserInterfaceException(
+                    sprintf('%s is not in an allowed status to place new orders.', $newPartner->getTitle())
+                );
             }
 
             $order->setPartner($newPartner);

--- a/src/Controller/SystemController.php
+++ b/src/Controller/SystemController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Configuration\AppConfiguration;
 use App\Entity\EAV\Definition;
 use App\Entity\Setting;
 use App\Transformers\UserTransformer;
@@ -60,19 +61,12 @@ class SystemController extends BaseController
      *
      * @return JsonResponse
      */
-    public function updateSettings(Request $request)
+    public function updateSettings(Request $request, AppConfiguration $appConfig)
     {
         $params = $this->getParams($request);
-        $repo = $this->getRepository(Setting::class);
 
         foreach ($params as $key => $param) {
-            $setting = $repo->find($key);
-            if (!$setting) {
-                $setting = new Setting();
-                $setting->setConfig($key);
-                $this->getEm()->persist($setting);
-            }
-            $setting->setValue($param);
+            $appConfig->set($key, $param);
         }
 
         $this->getEm()->flush();

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -4,11 +4,14 @@ namespace App\DataFixtures;
 
 use App\Entity\Address;
 use App\Entity\Contact;
+use App\Entity\Group;
 use App\Entity\ValueObjects\Name;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
 use Faker\Generator;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 abstract class BaseFixture extends Fixture
 {
@@ -17,6 +20,21 @@ abstract class BaseFixture extends Fixture
 
     /** @var Generator */
     protected $faker;
+
+    protected $tokenStorage;
+
+    public function __construct(TokenStorageInterface $storage)
+    {
+        $this->tokenStorage = $storage;
+
+        $token = new UsernamePasswordToken(
+            'fixtures',
+            null,
+            'main',
+            Group::AVAILABLE_ROLES);
+
+        $this->tokenStorage->setToken($token);
+    }
 
     abstract protected function loadData(ObjectManager $manager);
 

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -37,7 +37,8 @@ abstract class BaseFixture extends Fixture
             'fixtures',
             null,
             'main',
-            Group::AVAILABLE_ROLES);
+            Group::AVAILABLE_ROLES
+        );
 
         $this->tokenStorage->setToken($token);
     }

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -2,6 +2,7 @@
 
 namespace App\DataFixtures;
 
+use App\Configuration\AppConfiguration;
 use App\Entity\Address;
 use App\Entity\Contact;
 use App\Entity\Group;
@@ -24,9 +25,13 @@ abstract class BaseFixture extends Fixture
     /** @var TokenStorageInterface  */
     protected $tokenStorage;
 
-    public function __construct(TokenStorageInterface $storage)
+    /** @var AppConfiguration */
+    protected $config;
+
+    public function __construct(TokenStorageInterface $storage, AppConfiguration $config)
     {
         $this->tokenStorage = $storage;
+        $this->config = $config;
 
         $token = new UsernamePasswordToken(
             'fixtures',

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -21,6 +21,7 @@ abstract class BaseFixture extends Fixture
     /** @var Generator */
     protected $faker;
 
+    /** @var TokenStorageInterface  */
     protected $tokenStorage;
 
     public function __construct(TokenStorageInterface $storage)

--- a/src/DataFixtures/PartnerFixtures.php
+++ b/src/DataFixtures/PartnerFixtures.php
@@ -42,17 +42,15 @@ class PartnerFixtures extends BaseFixture
             $manager->persist($distributionMethod);
         }
 
-        $statuses = Partner::STATUSES + [
-            Partner::STATUS_ACTIVE,
-            Partner::STATUS_ACTIVE,
-            Partner::STATUS_ACTIVE,
-            Partner::STATUS_ACTIVE,
-        ];
+        $statuses = Partner::STATUSES;
 
         for ($i = 0; $i < 10; $i++) {
             $partner = new Partner($this->faker->company . ' Partner', $this->workflowRegistry);
             $partner->setPartnerType(Partner::TYPE_AGENCY);
-            $partner->setStatus($this->randValue($statuses));
+            $partner->setStatus($this->faker
+                ->optional(.5, Partner::STATUS_ACTIVE)
+                ->randomElement($statuses)
+            );
             $partner->setDistributionMethod($this->randValue($distributionMethods));
             $partner->setFulfillmentPeriod($this->randValue($periods));
             $partner->addContact($this->createContact(StorageLocationContact::class));
@@ -65,7 +63,10 @@ class PartnerFixtures extends BaseFixture
         for ($i = 0; $i < ($numStatuses * 2); $i++) {
             $hospital = new Partner($this->faker->company . ' Hospital', $this->workflowRegistry);
             $hospital->setPartnerType(Partner::TYPE_HOSPITAL);
-            $hospital->setStatus($statuses[$i % $numStatuses]);
+            $hospital->setStatus($this->faker
+                ->optional(.5, Partner::STATUS_ACTIVE)
+                ->randomElement($statuses)
+            );
             $hospital->setDistributionMethod($this->randValue($distributionMethods));
             $hospital->setFulfillmentPeriod($this->randValue($periods));
             $hospital->addContact($this->createContact(StorageLocationContact::class));

--- a/src/DataFixtures/PartnerFixtures.php
+++ b/src/DataFixtures/PartnerFixtures.php
@@ -49,8 +49,7 @@ class PartnerFixtures extends BaseFixture
             $partner->setPartnerType(Partner::TYPE_AGENCY);
             $partner->setStatus($this->faker
                 ->optional(.5, Partner::STATUS_ACTIVE)
-                ->randomElement($statuses)
-            );
+                ->randomElement($statuses));
             $partner->setDistributionMethod($this->randValue($distributionMethods));
             $partner->setFulfillmentPeriod($this->randValue($periods));
             $partner->addContact($this->createContact(StorageLocationContact::class));
@@ -65,8 +64,7 @@ class PartnerFixtures extends BaseFixture
             $hospital->setPartnerType(Partner::TYPE_HOSPITAL);
             $hospital->setStatus($this->faker
                 ->optional(.5, Partner::STATUS_ACTIVE)
-                ->randomElement($statuses)
-            );
+                ->randomElement($statuses));
             $hospital->setDistributionMethod($this->randValue($distributionMethods));
             $hospital->setFulfillmentPeriod($this->randValue($periods));
             $hospital->addContact($this->createContact(StorageLocationContact::class));

--- a/src/DataFixtures/SettingFixtures.php
+++ b/src/DataFixtures/SettingFixtures.php
@@ -24,10 +24,9 @@ class SettingFixtures extends BaseFixture implements DependentFixtureInterface
 
         $now = new Moment();
 
-        $this->config->create('partnerReviewStart', $now->cloning()->addMonths(1));
-        $this->config->create('partnerReviewEnd', $now->cloning()->addMonths(2));
-        $this->config->create('partnerReviewLastStartRun', $now->cloning()->subtractMonths(2));
-        $this->config->create('partnerReviewLastEndRun', $now->cloning()->subtractMonths(1));
-
+        $this->config->create('partnerReviewStart', $now->cloning()->addMonths(1)->format());
+        $this->config->create('partnerReviewEnd', $now->cloning()->addMonths(2)->format());
+        $this->config->create('partnerReviewLastStartRun', $now->cloning()->subtractMonths(2)->format());
+        $this->config->create('partnerReviewLastEndRun', $now->cloning()->subtractMonths(1)->format());
     }
 }

--- a/src/DataFixtures/SettingFixtures.php
+++ b/src/DataFixtures/SettingFixtures.php
@@ -2,9 +2,9 @@
 
 namespace App\DataFixtures;
 
-use App\Entity\Setting;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
+use Moment\Moment;
 
 class SettingFixtures extends BaseFixture implements DependentFixtureInterface
 {
@@ -19,16 +19,15 @@ class SettingFixtures extends BaseFixture implements DependentFixtureInterface
     {
         $pullupCategory = $this->getReference('product_category_training_pants');
 
-        $pullupCategorySetting = new Setting();
-        $pullupCategorySetting->setConfig('pullupCategory');
-        $pullupCategorySetting->setValue($pullupCategory->getId());
-        $em->persist($pullupCategorySetting);
+        $this->config->create('zipCountyStates', ['MO', 'KS']);
+        $this->config->create('pullupCategory', $pullupCategory->getId());
 
-        $pullupCategorySetting = new Setting();
-        $pullupCategorySetting->setConfig('zipCountyStates');
-        $pullupCategorySetting->setValue(['MO', 'KS']);
-        $em->persist($pullupCategorySetting);
+        $now = new Moment();
 
-        $em->flush();
+        $this->config->create('partnerReviewStart', $now->cloning()->addMonths(1));
+        $this->config->create('partnerReviewEnd', $now->cloning()->addMonths(2));
+        $this->config->create('partnerReviewLastStartRun', $now->cloning()->subtractMonths(2));
+        $this->config->create('partnerReviewLastEndRun', $now->cloning()->subtractMonths(1));
+
     }
 }

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -50,6 +50,7 @@ class Partner extends StorageLocation
     public const TRANSITION_SUBMIT = 'SUBMIT';
     public const TRANSITION_SUBMIT_PRIORITY = 'SUBMIT_PRIORITY';
     public const TRANSITION_ACTIVATE = 'ACTIVATE';
+    public const TRANSITION_REVIEWED = 'REVIEWED';
     public const TRANSITION_FLAG_FOR_REVIEW = 'FLAG_FOR_REVIEW';
     public const TRANSITION_FLAG_FOR_REVIEW_PAST_DUE = 'FLAG_FOR_REVIEW_PAST_DUE';
     public const TRANSITION_DEACTIVATE = 'DEACTIVATE';
@@ -243,5 +244,15 @@ class Partner extends StorageLocation
                 )
             );
         }
+    }
+
+    public function isReviewing(): bool
+    {
+        return in_array($this->status, [self::STATUS_NEEDS_PROFILE_REVIEW, self::STATUS_REVIEW_PAST_DUE]);
+    }
+
+    public function canPlaceOrders(): bool
+    {
+        return in_array($this->status, [self::STATUS_ACTIVE, self::STATUS_NEEDS_PROFILE_REVIEW]);
     }
 }

--- a/src/Entity/Partner.php
+++ b/src/Entity/Partner.php
@@ -103,6 +103,7 @@ class Partner extends StorageLocation
      *     inversedBy="partner",
      *     cascade={"persist", "remove"}
      * )
+     * @ORM\JoinColumn(onDelete="CASCADE")
      */
     protected $profile;
 

--- a/src/Entity/Setting.php
+++ b/src/Entity/Setting.php
@@ -24,7 +24,7 @@ class Setting
     /**
      * @var string
      *
-     * @ORM\Column(type="json")
+     * @ORM\Column(type="json", nullable=True)
      * @Gedmo\Versioned
      */
     protected $value;

--- a/src/Entity/Setting.php
+++ b/src/Entity/Setting.php
@@ -22,7 +22,7 @@ class Setting
     protected $config;
 
     /**
-     * @var string
+     * @var mixed
      *
      * @ORM\Column(type="json", nullable=True)
      * @Gedmo\Versioned

--- a/src/EventSubscriber/Workflow/PartnerSubscriber.php
+++ b/src/EventSubscriber/Workflow/PartnerSubscriber.php
@@ -65,7 +65,7 @@ class PartnerSubscriber implements EventSubscriberInterface
 
     public function onTransitionReviewed(GuardEvent $event): void
     {
-        if(!$this->checker->isGranted(Partner::ROLE_MANAGE_OWN)) {
+        if (!$this->checker->isGranted(Partner::ROLE_MANAGE_OWN)) {
             $event->setBlocked(true);
         }
     }

--- a/src/EventSubscriber/Workflow/PartnerSubscriber.php
+++ b/src/EventSubscriber/Workflow/PartnerSubscriber.php
@@ -63,6 +63,13 @@ class PartnerSubscriber implements EventSubscriberInterface
         }
     }
 
+    public function onTransitionReviewed(GuardEvent $event): void
+    {
+        if(!$this->checker->isGranted(Partner::ROLE_MANAGE_OWN)) {
+            $event->setBlocked(true);
+        }
+    }
+
     public function onTransitionDeactivate(GuardEvent $event): void
     {
         if (!$this->checker->isGranted(Partner::ROLE_EDIT_ALL)) {
@@ -79,6 +86,7 @@ class PartnerSubscriber implements EventSubscriberInterface
             'workflow.partner_management.guard.FLAG_FOR_REVIEW' => 'onTransitionFlagForReview',
             'workflow.partner_management.guard.FLAG_FOR_REVIEW_PAST_DUE' => 'onTransitionFlagForReviewPastDue',
             'workflow.partner_management.guard.ACTIVATE' => 'onTransitionActivate',
+            'workflow.partner_management.guard.REVIEWED' => 'onTransitionReviewed',
             'workflow.partner_management.guard.DEACTIVATE' => 'onTransitionDeactivate',
         ];
     }

--- a/src/Listener/PartnerListener.php
+++ b/src/Listener/PartnerListener.php
@@ -18,7 +18,7 @@ class PartnerListener implements EventSubscriber
         $this->workflowRegistry = $workflowRegistry;
     }
 
-    public function preUpdate(PreUpdateEventArgs $event)
+    public function preUpdate(PreUpdateEventArgs $event): void
     {
         $partner = $event->getEntity();
         if (!$partner instanceof Partner) {

--- a/src/Listener/PartnerListener.php
+++ b/src/Listener/PartnerListener.php
@@ -25,7 +25,7 @@ class PartnerListener implements EventSubscriber
             return;
         }
 
-        if($partner->isReviewing()) {
+        if($partner->isReviewing() && !$event->hasChangedField('status')) {
             $this->workflowRegistry
                 ->get($partner)
                 ->apply($partner, Partner::TRANSITION_REVIEWED);

--- a/src/Listener/PartnerListener.php
+++ b/src/Listener/PartnerListener.php
@@ -25,7 +25,7 @@ class PartnerListener implements EventSubscriber
             return;
         }
 
-        if($partner->isReviewing() && !$event->hasChangedField('status')) {
+        if ($partner->isReviewing() && !$event->hasChangedField('status')) {
             $this->workflowRegistry
                 ->get($partner)
                 ->apply($partner, Partner::TRANSITION_REVIEWED);

--- a/src/Listener/PartnerListener.php
+++ b/src/Listener/PartnerListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Listener;
+
+use App\Entity\Partner;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\Workflow\Registry;
+
+class PartnerListener implements EventSubscriber
+{
+    /** @var Registry */
+    protected $workflowRegistry;
+
+    public function __construct(Registry $workflowRegistry)
+    {
+        $this->workflowRegistry = $workflowRegistry;
+    }
+
+    public function preUpdate(PreUpdateEventArgs $event)
+    {
+        $partner = $event->getEntity();
+        if (!$partner instanceof Partner) {
+            return;
+        }
+
+        if($partner->isReviewing()) {
+            $this->workflowRegistry
+                ->get($partner)
+                ->apply($partner, Partner::TRANSITION_REVIEWED);
+        }
+    }
+
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::preUpdate,
+        ];
+    }
+}

--- a/src/Schedule/ClientExpirationSchedule.php
+++ b/src/Schedule/ClientExpirationSchedule.php
@@ -17,7 +17,7 @@ class ClientExpirationSchedule implements ScheduleBuilder
         $schedule->addCommand('app:client-expiration --force')
             ->description('Run client expiration job.')
             ->daily()
-            ->at(6)
+            ->at("06:00")
         ;
     }
 }

--- a/src/Schedule/PartnerReviewSchedule.php
+++ b/src/Schedule/PartnerReviewSchedule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Schedule;
+
+use Zenstruck\ScheduleBundle\Schedule;
+use Zenstruck\ScheduleBundle\Schedule\ScheduleBuilder;
+
+class PartnerReviewSchedule implements ScheduleBuilder
+{
+    public function buildSchedule(Schedule $schedule): void
+    {
+        $schedule
+            ->timezone('UTC')
+            ->environments('prod', 'stage')
+        ;
+
+        $schedule->addCommand('app:partner-review:run --force')
+            ->description('Run partner review job.')
+            ->daily()
+            ->at(6)
+        ;
+    }
+}

--- a/src/Schedule/PartnerReviewSchedule.php
+++ b/src/Schedule/PartnerReviewSchedule.php
@@ -17,7 +17,7 @@ class PartnerReviewSchedule implements ScheduleBuilder
         $schedule->addCommand('app:partner-review:run --force')
             ->description('Run partner review job.')
             ->daily()
-            ->at(6)
+            ->at("06:00")
         ;
     }
 }

--- a/src/Transformers/PartnerTransformer.php
+++ b/src/Transformers/PartnerTransformer.php
@@ -41,6 +41,7 @@ class PartnerTransformer extends StorageLocationTransformer
             'partnerType' => $partner->getPartnerType(),
             'legacyId' => $partner->getLegacyId(),
             'forecastAverageMonths' => $partner->getForecastAverageMonths(),
+            'canPlaceOrders' => $partner->canPlaceOrders(),
             'createdAt' => $partner->getCreatedAt()->format('c'),
             'updatedAt' => $partner->getUpdatedAt()->format('c'),
         ];

--- a/src/Transformers/StorageLocationTransformer.php
+++ b/src/Transformers/StorageLocationTransformer.php
@@ -2,6 +2,7 @@
 
 namespace App\Transformers;
 
+use App\Entity\Partner;
 use App\Entity\StorageLocation;
 use League\Fractal\TransformerAbstract;
 
@@ -24,6 +25,8 @@ class StorageLocationTransformer extends TransformerAbstract
             'status' => $storageLocation->getStatus(),
             'createdAt' => $storageLocation->getCreatedAt()->format('c'),
             'updatedAt' => $storageLocation->getUpdatedAt()->format('c'),
+            // For the record, I don't like this
+            'canPlaceOrders' => $storageLocation instanceof Partner ? $storageLocation->canPlaceOrders() : null,
             'type' => end($classpath),
 
         ];


### PR DESCRIPTION
Closes #195 

Partner Review start and end dates have been added to the settings, plus the time of the last start and end job were run. There is a schedule class that takes care of the recurring nature of this command.

When the review period starts, all "Active" partners will moved to "Needs Review". After the end of the review period, the command will change all "News Review" to "Review Past Due". The latter will prevent that partner from placing any more orders. If a partner update's their partner record in any of the review statuses, the partner will change back to "Active".  