### PR TITLE
Ensure Travis runs with just the coverage mode of Xdebug 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
           env:
               global:
                   - SYMFONY_PHPUNIT_DIR="$COMPOSER_BIN_DIR/.phpunit"
+                  - XDEBUG_MODE=coverage
           before_install:
               - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
               - chmod +x ./cc-test-reporter


### PR DESCRIPTION
There's a [known issue with the compiler pass in Symfony when Xdebug 3 is enabled](https://github.com/symfony/symfony/issues/39195). Even though we don't have Xdebug enabled yet, due to this known issue, we are using Xdebug 3 by default in Travis-CI.

This fix changes the Xdebug mode to just be for coverage. In my local tests of running the compiler pass using various modes, this seems to work. This also appears to be [the suggested fix in Travis forums](https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748).