### PR TITLE
200 partner order show previous client dist

### DIFF
--- a/assets/js/components/order/LineItemByClientFormRow.vue
+++ b/assets/js/components/order/LineItemByClientFormRow.vue
@@ -1,14 +1,22 @@
 <template>
     <div>
         <div>
-            <label :class="{'col-xs-6': showCost || showPacks, 'col-xs-8': !showCost && !showPacks }">
+            <div :class="{'col-xs-6': showCost || showPacks, 'col-xs-8': !showCost && !showPacks }">
                 <i
                     class="fa fa-plus-circle text-gray fa-fw"
                     title="Show/Hide Transactions"
                     @click="showTransactions = !showTransactions"
                 />
-                {{ value.client.fullName }}
-            </label>
+                <strong>{{ value.client.fullName }}</strong>
+
+                <div
+                    v-if="value.client.lastDistribution"
+                    class="pull-right"
+                >
+                    <span class="small">Last Distribution:</span> <span class="badge bg-light-blue">{{ value.client.lastDistribution.product.name }} x {{value.client.lastDistribution.quantity}}</span>
+                </div>
+
+            </div>
             <div
                 class="col-xs-2"
             >

--- a/assets/js/views/order/partner/PartnerOrderEdit.vue
+++ b/assets/js/views/order/partner/PartnerOrderEdit.vue
@@ -357,7 +357,9 @@
                 }
 
                 axios
-                    .get('/api/orders/partner/new-line-items-for-partner/' + partner.id)
+                    .get('/api/orders/partner/new-line-items-for-partner/' + partner.id, {
+                        params: { include: ['client.lastDistribution']}
+                    })
                     .then((response) => {
                             self.order.lineItems = response.data.data;
                             // resolve(response);

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -487,4 +487,20 @@ class Client extends CoreEntity
     {
         $this->lastReviewedAt = $lastReviewedAt;
     }
+
+    public function getLastCompleteDistributionLineItem(): ?BulkDistributionLineItem
+    {
+        $lines = $this->getDistributionLineItems();
+
+        $lines = $lines->filter(function(BulkDistributionLineItem $line) {
+            return $line->getOrder()->isComplete();
+        });
+
+        return array_reduce($lines->getValues(), function(?BulkDistributionLineItem $carry, BulkDistributionLineItem $line) {
+            if (!$carry) {
+                return $line;
+            }
+            return $carry->getDistributionPeriod() > $line->getDistributionPeriod() ? $carry : $line;
+        }, null);
+    }
 }

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -492,15 +492,19 @@ class Client extends CoreEntity
     {
         $lines = $this->getDistributionLineItems();
 
-        $lines = $lines->filter(function(BulkDistributionLineItem $line) {
+        $lines = $lines->filter(function (BulkDistributionLineItem $line) {
             return $line->getOrder()->isComplete();
         });
 
-        return array_reduce($lines->getValues(), function(?BulkDistributionLineItem $carry, BulkDistributionLineItem $line) {
-            if (!$carry) {
-                return $line;
-            }
-            return $carry->getDistributionPeriod() > $line->getDistributionPeriod() ? $carry : $line;
-        }, null);
+        return array_reduce(
+            $lines->getValues(),
+            function (?BulkDistributionLineItem $carry, BulkDistributionLineItem $line) {
+                if (!$carry) {
+                    return $line;
+                }
+                return $carry->getDistributionPeriod() > $line->getDistributionPeriod() ? $carry : $line;
+            },
+            null
+        );
     }
 }

--- a/src/Entity/Orders/BulkDistributionLineItem.php
+++ b/src/Entity/Orders/BulkDistributionLineItem.php
@@ -33,6 +33,14 @@ class BulkDistributionLineItem extends LineItem
         $this->client = $client;
     }
 
+    public function getDistributionPeriod(): ?\DateTime
+    {
+        /** @var BulkDistribution $order */
+        $order = $this->getOrder();
+
+        return $order ? $order->getDistributionPeriod() : null;
+    }
+
     /**
      * Partner Orders generate a deduction from the warehouse and an increase to the partner
      */

--- a/src/Entity/Orders/BulkDistributionLineItem.php
+++ b/src/Entity/Orders/BulkDistributionLineItem.php
@@ -38,7 +38,7 @@ class BulkDistributionLineItem extends LineItem
         /** @var BulkDistribution $order */
         $order = $this->getOrder();
 
-        return $order ? $order->getDistributionPeriod() : null;
+        return $this->hasOrder() ? $order->getDistributionPeriod() : null;
     }
 
     /**

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -10,6 +10,7 @@ class ClientTransformer extends TransformerAbstract
     protected $availableIncludes = [
         'partner',
         'attributes',
+        'lastDistribution',
     ];
 
     public function transform(Client $client): array
@@ -54,5 +55,10 @@ class ClientTransformer extends TransformerAbstract
         }
 
         return $this->item($client->getPartner(), new PartnerTransformer());
+    }
+
+    public function includeLastDistribution(Client $client)
+    {
+        return $this->item($client->getLastCompleteDistributionLineItem(), new BulkDistributionLineItemTransformer());
     }
 }

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -3,6 +3,7 @@
 namespace App\Transformers;
 
 use App\Entity\Client;
+use League\Fractal\Resource\Item;
 use League\Fractal\TransformerAbstract;
 
 class ClientTransformer extends TransformerAbstract
@@ -57,7 +58,7 @@ class ClientTransformer extends TransformerAbstract
         return $this->item($client->getPartner(), new PartnerTransformer());
     }
 
-    public function includeLastDistribution(Client $client)
+    public function includeLastDistribution(Client $client): Item
     {
         return $this->item($client->getLastCompleteDistributionLineItem(), new BulkDistributionLineItemTransformer());
     }


### PR DESCRIPTION
In the partner order screen the users now sees the product and quantity the client was given in the last distribution. This will make it easier to reorder the same size for a client.