### PR TITLE
174 client creation duplicate check

### DIFF
--- a/assets/js/components/AttributesEditForm.vue
+++ b/assets/js/components/AttributesEditForm.vue
@@ -2,7 +2,7 @@
     <div>
         <form role="form">
             <div
-                v-for="attribute in attributes"
+                v-for="attribute in attributes.filter(filter)"
                 :key="attribute.definition_id"
             >
                 <BooleanField
@@ -93,7 +93,8 @@
             BooleanField, RadioField, TextareaField, OptionListApi, NumberField, TextField, DateField},
         props: {
             new: { type: Boolean },
-            value: { type: Array, required: false }
+            value: { type: Array, required: true },
+            filter: { type: Function, required: false, default: (attribute) => true }
         },
         computed: {
             attributes: function () {

--- a/assets/js/routes.js
+++ b/assets/js/routes.js
@@ -69,8 +69,7 @@ let routes = [
     {
         path: '/clients/new',
         name: 'client-new',
-        component: require('./views/client/ClientEdit').default,
-        props: {new: true}
+        component: require('./views/client/ClientNewCheck').default
     },
     {path: '/clients/search', name: 'client-search', component: require('./views/client/ClientSearch').default},
     {path: '/clients/:id', name: 'client-edit', component: require('./views/client/ClientEdit').default},

--- a/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionEdit.vue
@@ -46,6 +46,11 @@
                                     placeholder="Enter help text"
                                 ></textarea>
                             </div>
+                            <BooleanField
+                                v-if="hasDuplicateCheck"
+                                v-model="definition.isDuplicateReference"
+                                label="Used when checking for duplicate records"
+                            />
                             <OptionListStatic
                                 v-model="definition.type"
                                 label="Attribute Type"
@@ -76,15 +81,18 @@
 import KeyValueField from "../../../components/KeyValueField";
 import {mapGetters} from "vuex";
 import OptionListStatic from "../../../components/OptionListStatic";
+import BooleanField from "../../../components/ToggleField";
 
 export default {
         name: 'AttributeDefinitionEdit',
         components: {
+            BooleanField,
             OptionListStatic,
             KeyValueField
         },
         props: {
             newForm: { type: Boolean, default: false },
+            hasDuplicateCheck: { type: Boolean, default: false },
             getApi: { type: String, required: true },
             postApi: { type: String, required: true },
             patchApi: { type: String, required: true },

--- a/assets/js/views/admin/attributes/AttributeDefinitionList.vue
+++ b/assets/js/views/admin/attributes/AttributeDefinitionList.vue
@@ -21,9 +21,10 @@
                 </router-link>
             </div>
         </div>
-        <h3 class="box-title">
-            Partner Profile Attribute List
-        </h3>
+        <h3
+            class="box-title"
+            v-text="title"
+        ></h3>
 
         <div class="row">
             <div class="col-xs-12">
@@ -82,6 +83,7 @@ export default {
             Draggable
         },
         props: {
+            title: { type: String, required: true },
             getApi: { type: String, required: true },
             orderApi: { type: String, required: true },
             editRoute: { type: [Object, String], required: true },

--- a/assets/js/views/admin/attributes/ClientAttributeDefinitionEdit.vue
+++ b/assets/js/views/admin/attributes/ClientAttributeDefinitionEdit.vue
@@ -6,6 +6,7 @@
         list-route="admin-client-attribute"
         definition-entity="Client"
         :new-form="newForm"
+        :has-duplicate-check="true"
     />
 </template>
 

--- a/assets/js/views/admin/attributes/ClientAttributeDefinitionList.vue
+++ b/assets/js/views/admin/attributes/ClientAttributeDefinitionList.vue
@@ -1,5 +1,6 @@
 <template>
     <AttributeDefinitionList
+        title="Client Profile Attribute List"
         edit-route="admin-client-attribute-edit"
         new-route="admin-client-attribute-new"
         get-api="/api/client/attribute/definition"

--- a/assets/js/views/admin/attributes/PartnerAttributeDefinitionList.vue
+++ b/assets/js/views/admin/attributes/PartnerAttributeDefinitionList.vue
@@ -1,5 +1,6 @@
 <template>
     <AttributeDefinitionList
+        title="Partner Profile Attribute List"
         edit-route="admin-partner-attribute-edit"
         new-route="admin-partner-attribute-new"
         get-api="/api/partner/attribute/definition"

--- a/assets/js/views/client/ClientEdit.vue
+++ b/assets/js/views/client/ClientEdit.vue
@@ -96,89 +96,9 @@
                                     </li>
                                 </ul>
                                 <div class="tab-content">
-                                    <div id="client_info" class="row tab-pane active">
-                                        <div class="col-md-6">
-                                            <div class="form-group">
-                                                <label>First Name</label>
-                                                <input
-                                                    v-model="client.firstName"
-                                                    type="text"
-                                                    class="form-control"
-                                                    placeholder="Enter first name"
-                                                >
-
-                                                <label>Last Name</label>
-                                                <input
-                                                    v-model="client.lastName"
-                                                    type="text"
-                                                    class="form-control"
-                                                    placeholder="Enter last name"
-                                                >
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Parent/Guardian First Name</label>
-                                                <input
-                                                    v-model="client.parentFirstName"
-                                                    type="text"
-                                                    class="form-control"
-                                                    placeholder="Enter parent or guardian first name"
-                                                >
-
-                                                <label>Parent/GuardianLast Name</label>
-                                                <input
-                                                    v-model="client.parentLastName"
-                                                    type="text"
-                                                    class="form-control"
-                                                    placeholder="Enter parent or guarding last name"
-                                                >
-                                            </div>
-                                            <DateField
-                                                v-model="client.birthdate"
-                                                label="Birthdate"
-                                                format="YYYY-MM-DD"
-                                            />
-                                            <PartnerSelectionForm
-                                                v-model="client.partner"
-                                                label="Assigned Partner"
-                                            />
-                                        </div>
-                                        <div class="col-md-6">
-                                            <div class="box box-info">
-                                                <div class="box-header with-border">
-                                                    <h3 class="box-title">
-                                                        <i class="icon far fa-clock fa-fw" />Expiration Info
-                                                    </h3>
-                                                </div>
-                                                <!-- /.box-header -->
-                                                <div class="box-body">
-                                                    <!-- text input -->
-                                                    <BooleanField
-                                                        v-model="client.isExpirationOverridden"
-                                                        label="Override Expirations"
-                                                    />
-                                                    <DateField
-                                                        v-model="client.ageExpiresAt"
-                                                        label="Age Expiration"
-                                                        format="YYYY-MM-DD"
-                                                    />
-                                                    <DateField
-                                                        v-model="client.distributionExpiresAt"
-                                                        label="Distribution Expiration"
-                                                        format="YYYY-MM-DD"
-                                                    />
-                                                    <NumberField
-                                                        v-model="client.pullupDistributionMax"
-                                                        label="Pullup Maximum Limit"
-                                                    />
-                                                    <DisplayField
-                                                        v-model="client.pullupDistributionCount"
-                                                        label="Pullup Distributions"
-                                                    />
-                                                </div>
-                                                <!-- /.box-body -->
-                                            </div>
-                                        </div>
-                                    </div>
+                                    <ClientInfoForm
+                                        v-model="client"
+                                    />
                                     <AttributesEditForm
                                         id="profile_tab"
                                         v-model="client.attributes"
@@ -220,22 +140,14 @@
 <script>
 import Modal from '../../components/Modal.vue';
 import AttributesEditForm from "../../components/AttributesEditForm";
-import PartnerSelectionForm from "../../components/PartnerSelectionForm";
-import DateField from "../../components/DateField";
-import BooleanField from "../../components/ToggleField";
-import NumberField from "../../components/NumberField";
-import DisplayField from "../../components/DisplayField";
 import ClientDistributionHistory from "./ClientDistributionHistory";
+import ClientInfoForm from "./ClientInfoForm";
 
 export default {
         name: 'ClientEdit',
         components: {
+            ClientInfoForm,
             ClientDistributionHistory,
-            DisplayField,
-            NumberField,
-            BooleanField,
-            DateField,
-            PartnerSelectionForm,
             AttributesEditForm,
             'modal' : Modal
         },
@@ -264,7 +176,7 @@ export default {
             if (!this.new) {
                 axios
                     .get('/api/clients/' + this.$route.params.id, {
-                        params: { include: ['partner', 'attributes']}
+                        params: { include: ['partner', 'attributes', 'attributes.options']}
                     })
                     .then(response => {
                         self.client = response.data.data;

--- a/assets/js/views/client/ClientInfoForm.vue
+++ b/assets/js/views/client/ClientInfoForm.vue
@@ -1,0 +1,123 @@
+<template>
+    <div id="client_info" class="row tab-pane active">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label>First Name</label>
+                <input
+                    v-model="value.firstName"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter first name"
+                >
+
+                <label>Last Name</label>
+                <input
+                    v-model="value.lastName"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter last name"
+                >
+            </div>
+            <div class="form-group">
+                <label>Parent/Guardian First Name</label>
+                <input
+                    v-model="value.parentFirstName"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter parent or guardian first name"
+                >
+
+                <label>Parent/Guardian Last Name</label>
+                <input
+                    v-model="value.parentLastName"
+                    type="text"
+                    class="form-control"
+                    placeholder="Enter parent or guardian last name"
+                >
+            </div>
+            <DateField
+                v-model="value.birthdate"
+                label="Birthdate"
+                format="YYYY-MM-DD"
+            />
+            <PartnerSelectionForm
+                v-model="value.partner"
+                label="Assigned Partner"
+            />
+        </div>
+        <div class="col-md-6">
+            <div v-if="showExpirations" class="box box-info">
+                <div class="box-header with-border">
+                    <h3 class="box-title">
+                        <i class="icon far fa-clock fa-fw" />Expiration Info
+                    </h3>
+                </div>
+                <!-- /.box-header -->
+                <div class="box-body">
+                    <!-- text input -->
+                    <BooleanField
+                        v-model="value.isExpirationOverridden"
+                        label="Override Expirations"
+                    />
+                    <DateField
+                        v-model="value.ageExpiresAt"
+                        label="Age Expiration"
+                        format="YYYY-MM-DD"
+                    />
+                    <DateField
+                        v-model="value.distributionExpiresAt"
+                        label="Distribution Expiration"
+                        format="YYYY-MM-DD"
+                    />
+                    <NumberField
+                        v-model="value.pullupDistributionMax"
+                        label="Pullup Maximum Limit"
+                    />
+                    <DisplayField
+                        v-model="value.pullupDistributionCount"
+                        label="Pullup Distributions"
+                    />
+                </div>
+                <!-- /.box-body -->
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import PartnerSelectionForm from "../../components/PartnerSelectionForm";
+import DateField from "../../components/DateField";
+import BooleanField from "../../components/ToggleField";
+import NumberField from "../../components/NumberField";
+import DisplayField from "../../components/DisplayField";
+import ClientDistributionHistory from "./ClientDistributionHistory";
+
+export default {
+    name: 'ClientInfoForm',
+    components: {
+        DisplayField,
+        NumberField,
+        BooleanField,
+        DateField,
+        PartnerSelectionForm
+    },
+    props: {
+        new: {
+            type: Boolean,
+            default: false,
+            required: false
+        },
+        showExpirations: {
+            type: Boolean,
+            default: true,
+            required: false
+        },
+        value: { required: true, type: [Object, Array] },
+    },
+    created() {
+        let self = this;
+
+        console.log('ClientEdit Component mounted.');
+    },
+}
+</script>

--- a/assets/js/views/client/ClientNewCheck.vue
+++ b/assets/js/views/client/ClientNewCheck.vue
@@ -87,8 +87,8 @@
             v-if="foundDuplicates"
             id="duplicates"
         >
-            <div class="alert alert-danger">
-                <h3 class="alert-heading">Duplicate Clients Found</h3>
+            <div class="callout callout-danger">
+                <h3>Duplicate Clients Found</h3>
                 Based on the information provided, this client appears to be a duplicate of the following client(s). If inactive, please transfer a client below to your partner agency.
             </div>
             <div class="row">
@@ -104,11 +104,19 @@
                                     <th></th>
                                 </thead>
                                 <tbody>
-                                    <tr v-for="duplicate in duplicates">
+                                    <tr
+                                        v-for="duplicate in duplicates"
+                                        :key="duplicate.id"
+                                    >
                                         <td v-text="duplicate.fullName"></td>
                                         <td v-text="duplicate.status"></td>
                                         <td v-text="duplicate.partner.title"></td>
-                                        <td v-text="duplicate.lastDistribution.order.distributionPeriod"></td>
+                                        <td>
+                                            <span
+                                                v-if="duplicate.lastDistribution"
+                                                v-text="duplicate.lastDistribution.order.distributionPeriod"
+                                            ></span>
+                                        </td>
                                         <td></td>
                                     </tr>
                                 </tbody>

--- a/assets/js/views/client/ClientNewCheck.vue
+++ b/assets/js/views/client/ClientNewCheck.vue
@@ -1,0 +1,219 @@
+<template>
+    <section class="content">
+        <div class="pull-right">
+            <button
+                v-if="noDuplicates"
+                class="btn btn-success btn-flat"
+                @click.prevent="save"
+            >
+                <i class="fa fa-save fa-fw" />
+                Save Client
+            </button>
+            <button
+                v-if="!checked"
+                class="btn btn-primary btn-flat"
+                @click="check()"
+            >
+                <i class="fa fa-search fa-fw" />
+                Check for Duplicate
+            </button>
+        </div>
+
+        <h3 class="box-title">
+            New Client
+        </h3>
+
+        <section
+            v-if="!checked"
+            id="new-client-check"
+        >
+            <div class="row">
+                <form role="form">
+                    <div class="col-md-12">
+                        <div class="box box-info">
+                            <div class="box-header with-border">
+                                <h3 class="box-title">
+                                    <i class="icon fa fa-child fa-fw" />Client Info
+                                </h3>
+                            </div>
+                            <!-- /.box-header -->
+                            <div class="box-body">
+                                <div id="client_info" class="row active">
+                                    <div class="col-md-6">
+                                        <div class="form-group">
+                                            <label>First Name</label>
+                                            <input
+                                                v-model="client.firstName"
+                                                type="text"
+                                                class="form-control"
+                                                placeholder="Enter first name"
+                                            >
+
+                                            <label>Last Name</label>
+                                            <input
+                                                v-model="client.lastName"
+                                                type="text"
+                                                class="form-control"
+                                                placeholder="Enter last name"
+                                            >
+                                        </div>
+                                        <DateField
+                                            v-model="client.birthdate"
+                                            label="Birthdate"
+                                            format="YYYY-MM-DD"
+                                        />
+                                    </div>
+                                </div>
+                                <AttributesEditForm
+                                    id="profile_tab"
+                                    v-model="client.attributes"
+                                    :filter="(attribute) => attribute.isDuplicateReference"
+                                />
+                                <!-- text input -->
+
+                            </div>
+                            <!-- /.box-body -->
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                </div>
+            </div>
+        </section>
+
+        <section
+            v-if="foundDuplicates"
+            id="duplicates"
+        >
+            <div class="alert alert-danger">
+                <h3 class="alert-heading">Duplicate Clients Found</h3>
+                Based on the information provided, this client appears to be a duplicate of the following client(s). If inactive, please transfer a client below to your partner agency.
+            </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="box">
+                        <div class="box-body">
+                            <table class="table table-hover">
+                                <thead>
+                                    <th>Name</th>
+                                    <th>Status</th>
+                                    <th>Partner</th>
+                                    <th>Last Activity</th>
+                                    <th></th>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="duplicate in duplicates">
+                                        <td v-text="duplicate.fullName"></td>
+                                        <td v-text="duplicate.status"></td>
+                                        <td v-text="duplicate.partner.title"></td>
+                                        <td v-text="duplicate.lastDistribution.order.distributionPeriod"></td>
+                                        <td></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                        </div>
+                    </div>
+
+                </div>
+
+            </div>
+        </section>
+
+        <section
+            v-if="noDuplicates"
+            id="new-client">
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="box">
+                        <div class="box-body">
+                            <ClientInfoForm
+                                v-model="client"
+                                :show-expirations="false"
+                            />
+                            <AttributesEditForm
+                                v-model="client.attributes"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </section>
+
+
+</template>
+
+<script>
+import AttributesEditForm from "../../components/AttributesEditForm";
+import PartnerSelectionForm from "../../components/PartnerSelectionForm";
+import DateField from "../../components/DateField";
+import BooleanField from "../../components/ToggleField";
+import NumberField from "../../components/NumberField";
+import DisplayField from "../../components/DisplayField";
+import TableStatic from "../../components/TableStatic";
+import ClientInfoForm from "./ClientInfoForm";
+
+export default {
+    name: 'ClientNewCheck',
+    components: {
+        ClientInfoForm,
+        DateField,
+        AttributesEditForm,
+    },
+    data() {
+        return {
+            client: {
+                attributes: [],
+                partner: {},
+            },
+            duplicates: [],
+            checked: false
+        };
+    },
+    computed: {
+        foundDuplicates: function() { return this.checked && this.duplicates.length > 0 },
+        noDuplicates: function() { return this.checked && this.duplicates.length === 0 }
+    },
+    created() {
+        let self = this;
+        axios
+            .get('/api/clients/fields', {
+                params: { include: ['options']}
+            })
+            .then(response => this.client.attributes = response.data.data)
+            .catch(function (error) {
+                console.log("Save this.client error %o", error);
+            });
+        console.log('ClientEdit Component mounted.');
+    },
+    methods: {
+        check: function () {
+            let self = this;
+            axios
+                .post('/api/clients/new-check', this.client, {
+                    params: { include: ['partner', 'lastDistribution', 'lastDistribution.order']}
+                })
+                .then(response => {
+                    self.duplicates = response.data.data;
+                    self.checked = true;
+                })
+                .catch(function (error) {
+                    console.log("Save this.client error %o", error);
+                });
+        },
+        save: function () {
+            let self = this;
+            axios
+                .post('/api/clients', this.client)
+                .then(response => self.$router.push({ name: 'clients' }))
+                .catch(function (error) {
+                    console.log("Save this.client error %o", error);
+                });
+        },
+    }
+}
+</script>

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -51,7 +51,7 @@ abstract class BaseController extends AbstractController
     {
         $transformer = $transformer ?: $this->getDefaultTransformer();
 
-        if ($entities instanceof \Iterator || is_array($entities)) {
+        if ($entities instanceof \Traversable || is_array($entities)) {
             $resource = new Collection($entities, $transformer, 'data');
         } else {
             $resource = new Item($entities, $transformer, 'data');

--- a/src/Controller/ClientAttributeDefinitionController.php
+++ b/src/Controller/ClientAttributeDefinitionController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\EAV\ClientDefinition;
+use App\Transformers\ClientAttributeDefinitionTransformer;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -18,5 +19,10 @@ class ClientAttributeDefinitionController extends BaseAttributeDefinitionControl
     protected function getNewDefinition()
     {
         return new ClientDefinition();
+    }
+
+    protected function getDefaultTransformer(): ClientAttributeDefinitionTransformer
+    {
+        return new ClientAttributeDefinitionTransformer();
     }
 }

--- a/src/Entity/EAV/ClientDefinition.php
+++ b/src/Entity/EAV/ClientDefinition.php
@@ -12,4 +12,27 @@ use Doctrine\ORM\Mapping as ORM;
 class ClientDefinition extends Definition
 {
     public $defaultEntityName = ClientDefinition::class;
+
+    /**
+     * @var boolean|null
+     *
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $isDuplicateReference;
+
+    /**
+     * @return bool
+     */
+    public function isDuplicateReference(): ?bool
+    {
+        return $this->isDuplicateReference;
+    }
+
+    /**
+     * @param bool $isDuplicateReference
+     */
+    public function setIsDuplicateReference(?bool $isDuplicateReference): void
+    {
+        $this->isDuplicateReference = $isDuplicateReference;
+    }
 }

--- a/src/Entity/EAV/Definition.php
+++ b/src/Entity/EAV/Definition.php
@@ -444,6 +444,13 @@ abstract class Definition extends CoreEntity
         return $attribute;
     }
 
+    public function getAttributeClass(): string
+    {
+        $attribute = self::createNewAttributeFromType($this->type);
+
+        return get_class($attribute);
+    }
+
     public function applyChangesFromArray(array $changes): void
     {
         if (isset($changes['options'])) {

--- a/src/Listener/ClientListener.php
+++ b/src/Listener/ClientListener.php
@@ -46,6 +46,10 @@ class ClientListener implements EventSubscriber
             return;
         }
 
+        if (!$client->getPublicId()) {
+            $client->setPublicId($this->gen->generate());
+        }
+
         $client->calculateAgeExpiration();
     }
 
@@ -54,10 +58,6 @@ class ClientListener implements EventSubscriber
         $client = $event->getEntity();
         if (!$client instanceof Client) {
             return;
-        }
-
-        if (!$client->getPublicId()) {
-            $client->setPublicId($this->gen->generate());
         }
 
         $client->calculateAgeExpiration();

--- a/src/Transformers/AttributeTransformer.php
+++ b/src/Transformers/AttributeTransformer.php
@@ -17,10 +17,7 @@ class AttributeTransformer extends TransformerAbstract
         'value'
     ];
 
-    /**
-     * @return array
-     */
-    public function transform(Attribute $attribute)
+    public function transform(Attribute $attribute): array
     {
         return [
             'id' => (int) $attribute->getId(),

--- a/src/Transformers/ClientAttributeDefinitionTransformer.php
+++ b/src/Transformers/ClientAttributeDefinitionTransformer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Entity\EAV\ClientDefinition;
+use App\Entity\EAV\Definition;
+
+class ClientAttributeDefinitionTransformer extends AttributeDefinitionTransformer
+{
+    /**
+     * @param ClientDefinition $attribute
+     * @return array
+     */
+    public function transform(Definition $attribute)
+    {
+        $fields = parent::transform($attribute);
+        $fields['isDuplicateReference'] = $attribute->isDuplicateReference();
+
+        return $fields;
+    }
+}

--- a/src/Transformers/ClientAttributeTransformer.php
+++ b/src/Transformers/ClientAttributeTransformer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Entity\EAV\Attribute;
+use App\Entity\EAV\ClientDefinition;
+
+class ClientAttributeTransformer extends AttributeTransformer
+{
+    /**
+     * @param Attribute $attribute
+     * @return array
+     */
+    public function transform(Attribute $attribute): array
+    {
+        /** @var ClientDefinition $definition */
+        $definition = $attribute->getDefinition();
+
+        $fields = parent::transform($attribute);
+        $fields['isDuplicateReference'] = $definition->isDuplicateReference();
+
+        return $fields;
+    }
+}

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -61,7 +61,10 @@ class ClientTransformer extends TransformerAbstract
     public function includeLastDistribution(Client $client): ?Item
     {
         if ($client->getLastCompleteDistributionLineItem()) {
-            return $this->item($client->getLastCompleteDistributionLineItem(), new BulkDistributionLineItemTransformer());
+            return $this->item(
+                $client->getLastCompleteDistributionLineItem(),
+                new BulkDistributionLineItemTransformer()
+            );
         }
 
         return null;

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -58,8 +58,12 @@ class ClientTransformer extends TransformerAbstract
         return $this->item($client->getPartner(), new PartnerTransformer());
     }
 
-    public function includeLastDistribution(Client $client): Item
+    public function includeLastDistribution(Client $client): ?Item
     {
-        return $this->item($client->getLastCompleteDistributionLineItem(), new BulkDistributionLineItemTransformer());
+        if ($client->getLastCompleteDistributionLineItem()) {
+            return $this->item($client->getLastCompleteDistributionLineItem(), new BulkDistributionLineItemTransformer());
+        }
+
+        return null;
     }
 }

--- a/tests/Controller/ClientControllerTest.php
+++ b/tests/Controller/ClientControllerTest.php
@@ -73,7 +73,7 @@ class ClientControllerTest extends AbstractWebTestCase
 
         $newLastName = uniqid();
 
-        $params['name'] = ['firstName' => $firstName, 'lastName' => $newLastName];
+        $params = ['firstName' => $firstName, 'lastName' => $newLastName];
 
         $this->client->request('PATCH', "/api/clients/{$publicId}", $params);
 


### PR DESCRIPTION
This adds a new "New Client" view that will give the user a subset of fields they need to enter to check of duplicates. If there are no duplicates, it will provide them with the rest of the fields to create the client. If there are duplicates, it will present the user with a list of duplicate clients. Later ticket will add the ability to transfer a client to their agency from that list.

To support this feature, the hard coded client fields were extracted in to its own component so that it can be used in the edit and new client screen.

This also adds a flag for custom fields to be included when checking for duplicates.