### PR TITLE
175 transfer clients

### DIFF
--- a/assets/js/components/TableStatic.vue
+++ b/assets/js/components/TableStatic.vue
@@ -33,6 +33,12 @@
                     <i class="fa fa-edit" /> {{ props.rowData[linkDisplayProperty] }}
                 </router-link>
             </template>
+            <template v-slot:actions="{rowData}">
+                <slot
+                    name="actions"
+                    :rowData="rowData"
+                />
+            </template>
         </vuetable>
     </div>
 </template>
@@ -50,7 +56,7 @@
         props:{
             columns: { type: Array, required: true },
             apiUrl: { type: String, required: true },
-            httpMethod: { type: String, required: true, default: 'get' },
+            httpMethod: { type: String, default: 'get' },
             editRoute: { type: String },
             sortOrder: { type: Array },
             params: { type: Object },

--- a/assets/js/store/modules/system.js
+++ b/assets/js/store/modules/system.js
@@ -17,7 +17,7 @@ const getters = {
     },
     userActivePartner: (state) => {
         if (state.user == null) return false;
-        return state.user.activePartner
+        return state.user.activePartner || null
     },
     userPartners: (state) => {
         if (state.user == null) return false;

--- a/assets/js/views/client/ClientTransferModal.vue
+++ b/assets/js/views/client/ClientTransferModal.vue
@@ -1,0 +1,44 @@
+<template>
+    <modal
+        id="clientTransferModal"
+        classes="modal-info"
+        :confirm-action="transferClient"
+    >
+        <template slot="header">
+            Transfer Client
+        </template>
+
+        Transfer <strong>{{ client.fullName }}</strong> to <strong>{{ targetPartner.title }}</strong>?
+
+        <template slot="confirmButton">
+            <i class="fa fa-exchange-alt"></i> Transfer
+        </template>
+    </modal>
+</template>
+
+
+<script>
+    import Modal from '../../components/Modal.vue';
+
+    export default {
+        name: 'ClientTransferModal',
+        components: {
+            'modal' : Modal,
+        },
+        props: {
+            client: { type: Object, required: true },
+            targetPartner: { type: Object, required: true }
+        },
+        methods: {
+            transferClient: function() {
+                let me = this;
+                axios
+                    .post('/api/clients/'+this.client.id+'/transfer', )
+                    .then(response => me.$router.push({name: 'client-edit', params: {id: response.data.data.id}}))
+                    .catch(function (error) {
+                        console.log(error);
+                    });
+            }
+        }
+    }
+</script>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1096,11 +1096,6 @@ parameters:
 			path: src/Entity/Address.php
 
 		-
-			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$partner type mapping mismatch\\: database can contain App\\\\Entity\\\\Partner\\|null but property expects App\\\\Entity\\\\Partner\\.$#"
-			count: 1
-			path: src/Entity/Client.php
-
-		-
 			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$ageExpiresAt type mapping mismatch\\: database can contain DateTime\\|null but property expects DateTime\\.$#"
 			count: 1
 			path: src/Entity/Client.php

--- a/src/Controller/ClientController.php
+++ b/src/Controller/ClientController.php
@@ -391,11 +391,14 @@ class ClientController extends BaseController
         $client = $this->getClientById($publicId);
         $this->denyAccessUnlessGranted(ClientVoter::TRANSFER, $client);
 
-        if(!$this->getUser()->getActivePartner()) {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if (!$user->getActivePartner()) {
             throw new UserInterfaceException("Current logged in user has no active partner or is an admin.");
         }
 
-        $partner = $this->getUser()->getActivePartner();
+        $partner = $user->getActivePartner();
 
         $client->setPartner($partner);
 

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -91,6 +91,7 @@ class Client extends CoreEntity
      * @var string|null
      *
      * @ORM\Column(type="string", nullable=true)
+     * @Gedmo\Versioned
      */
     protected $parentFirstName;
 
@@ -98,6 +99,7 @@ class Client extends CoreEntity
      * @var string|null
      *
      * @ORM\Column(type="string", nullable=true)
+     * @Gedmo\Versioned
      */
     protected $parentLastName;
 
@@ -367,11 +369,6 @@ class Client extends CoreEntity
         return $this->pullupDistributionCount >= $this->pullupDistributionMax;
     }
 
-    public function applyChangesFromArray(array $changes): void
-    {
-        parent::applyChangesFromArray($changes);
-    }
-
     public function getPartner(): ?Partner
     {
         return $this->partner;
@@ -506,5 +503,21 @@ class Client extends CoreEntity
             },
             null
         );
+    }
+
+    /**
+     * Clients are considered active if they are "ACTIVE" or "NEEDS REVIEW"
+     */
+    public function isActive(): bool
+    {
+        return in_array($this->status, [self::STATUS_ACTIVE, self::STATUS_NEEDS_REVIEW]);
+    }
+
+    /**
+     * Partners can only transfer clients to themselves if they are (regular) Inactive or Creating
+     */
+    public function canPartnerTransfer(): bool
+    {
+        return in_array($this->status, [self::STATUS_INACTIVE, self::STATUS_CREATION]);
     }
 }

--- a/src/Entity/Client.php
+++ b/src/Entity/Client.php
@@ -104,7 +104,7 @@ class Client extends CoreEntity
     protected $parentLastName;
 
     /**
-     * @var Partner
+     * @var Partner|null
      *
      * @ORM\ManyToOne(targetEntity="App\Entity\Partner", inversedBy="clients")
      * @Gedmo\Versioned
@@ -374,7 +374,7 @@ class Client extends CoreEntity
         return $this->partner;
     }
 
-    public function setPartner(Partner $partner): void
+    public function setPartner(?Partner $partner): void
     {
         $this->partner = $partner;
     }

--- a/src/Security/ClientVoter.php
+++ b/src/Security/ClientVoter.php
@@ -106,6 +106,4 @@ class ClientVoter extends Voter
 
         return false;
     }
-
-
 }

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -41,6 +41,8 @@ class ClientTransformer extends TransformerAbstract
             'createdAt' => $client->getCreatedAt()->format('c'),
             'status' => $client->getStatus(),
             'canReview' => $client->canReview(),
+            'canPartnerTransfer' => $client->canPartnerTransfer(),
+            'isActive' => $client->isActive(),
         ];
     }
 
@@ -51,11 +53,9 @@ class ClientTransformer extends TransformerAbstract
 
     public function includePartner(Client $client)
     {
-        if (!$client->getPartner()) {
-            return;
-        }
-
-        return $this->item($client->getPartner(), new PartnerTransformer());
+        return $client->getPartner()
+            ? $this->item($client->getPartner(), new PartnerTransformer())
+            : $this->primitive(['id'=>null]);
     }
 
     public function includeLastDistribution(Client $client): ?Item

--- a/src/Transformers/ClientTransformer.php
+++ b/src/Transformers/ClientTransformer.php
@@ -55,7 +55,7 @@ class ClientTransformer extends TransformerAbstract
     {
         return $client->getPartner()
             ? $this->item($client->getPartner(), new PartnerTransformer())
-            : $this->primitive(['id'=>null]);
+            : $this->primitive(['id' => null]);
     }
 
     public function includeLastDistribution(Client $client): ?Item


### PR DESCRIPTION
Client Transfer

If a client is Inactive a partner can transfer that client to their current active partner by click new buttons on either the Client Search or Duplicate check when creating a new client. This has to be done as a logged in partner. Managers/Admins should change the partner through the client edit screen.